### PR TITLE
Revert .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,9 +3,4 @@ root = true
 [*]
 indent_style = space
 trim_trailing_whitespace = true
-
-# The indent size used in the `package.json` file cannot be changed
-# https://github.com/npm/npm/pull/3180#issuecomment-16336516
-[{*.yml,*.yaml,package.json}]
-indent_style = space
 indent_size = 2


### PR DESCRIPTION
I have been wondering why my editor is not defaulting to two spaces and
it is because indent_size was removed from the * block.

I am not sure why we would need a separate block for package.json and
yaml anyway since they use the same settings as the rest of our code.

I would revert the commit but this change was made in a larger commit
with a bunch of unrelated changes.
