### PR TITLE
fix(ci): add environment to docs-preview

### DIFF
--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -21,6 +21,7 @@ jobs:
   preview:
     name: Docs preview
     runs-on: ubuntu-20.04
+    environment: CI
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1


### PR DESCRIPTION
This PR updates the `docs-preview.yaml` workflow to use an environment which should have the correct secrets for deploying a docs preview.

Fixes #4027 
