### PR TITLE
feat: add tests for node/settings.ts

### DIFF
--- a/test/unit/node/settings.test.ts
+++ b/test/unit/node/settings.test.ts
@@ -1,0 +1,62 @@
+import { logger } from "@coder/logger"
+import { promises as fs } from "fs"
+import path from "path"
+import { SettingsProvider, CoderSettings } from "../../../src/node/settings"
+import { clean, mockLogger, tmpdir } from "../../utils/helpers"
+
+describe("settings", () => {
+  const testName = "settingsTests"
+  let testDir = ""
+
+  beforeAll(async () => {
+    mockLogger()
+    await clean(testName)
+    testDir = await tmpdir(testName)
+  })
+  describe("with invalid JSON in settings file", () => {
+    let mockSettingsFile = "coder.json"
+    let pathToMockSettingsFile = ""
+
+    beforeEach(async () => {
+      pathToMockSettingsFile = path.join(testDir, mockSettingsFile)
+      // Missing a quote, which makes it invalid intentionally
+      await fs.writeFile(pathToMockSettingsFile, '{"fakeKey":true,"helloWorld:"test"}')
+    })
+    afterEach(async () => {
+      jest.clearAllMocks()
+    })
+    it("should log a warning", async () => {
+      const settings = new SettingsProvider<CoderSettings>(pathToMockSettingsFile)
+      await settings.read()
+      // This happens when we can't parse a JSON (usually error in file)
+      expect(logger.warn).toHaveBeenCalledWith("Unexpected token t in JSON at position 29")
+    })
+  })
+  describe("with invalid settings file path", () => {
+    let mockSettingsFile = "nonExistent.json"
+    let pathToMockSettingsFile = ""
+
+    beforeEach(async () => {
+      // Add hello so it's a directory that doesn't exist
+      // NOTE: if we don't have that, it fails the test
+      // That's because it will write a file if it doesn't exist
+      // but it throws if there's a directory in the path that
+      // doesn't exist.
+      pathToMockSettingsFile = path.join(testDir, "hello", mockSettingsFile)
+    })
+    afterEach(async () => {
+      jest.clearAllMocks()
+    })
+    it("should log a warning", async () => {
+      const settings = new SettingsProvider<CoderSettings>(pathToMockSettingsFile)
+      await settings.write({
+        update: {
+          checked: 2,
+          version: "4.0.1",
+        },
+      })
+      // This happens if it tries to writeFile to a nonexistent path
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("ENOENT: no such file or directory"))
+    })
+  })
+})


### PR DESCRIPTION
This PR adds additional tests for `node/settings.ts` to ensure we log warnings when expected.

## Context
The `SettingsProvider` provides the application with access to the settings for code-server. This is then added to all routes under `req.settings` so they can easily access it. We're adding tests to ensure that our logger does indeed log warnings when something goes wrong.

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/3806031/148822869-bfe131e3-ef19-492e-a0c9-feedbfb04fe1.png)

### After
![image](https://user-images.githubusercontent.com/3806031/148829900-28485e4d-2b33-4518-b1d3-a2b7d6b30e6d.png)

Fixes N/A
#TestingMondays
