### PR TITLE
chore: use 1.14.7 follow-redirects

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "vfile-message": "^2.0.2",
     "tar": "^6.1.9",
     "path-parse": "^1.0.7",
-    "vm2": "^3.9.4"
+    "vm2": "^3.9.4",
+    "follow-redirects": "^1.14.7"
   },
   "dependencies": {
     "@coder/logger": "1.1.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1879,10 +1879,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
-follow-redirects@^1.0.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
-  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
+follow-redirects@^1.0.0, follow-redirects@^1.14.7:
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
+  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
 
 format@^0.2.0:
   version "0.2.2"


### PR DESCRIPTION
This PR upgrades `follow-redirects` based on a vulnerability report. 

Fixes N/A