### PR TITLE
chore: update bug-report.yaml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -27,7 +27,20 @@ body:
         - Remote Architecture:
         - `code-server --version`:
     validations:
-      required: false
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+      description: |
+        1. open code-server
+        2. install extension
+        3. run command
+      value: |
+        1. 
+        2.
+        3.
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: Expected

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -26,7 +26,6 @@ body:
         - Remote OS:
         - Remote Architecture:
         - `code-server --version`:
-      render: markdown
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
Fix `OS/Web Information` section and don't render as Markdown.

This will fix this issue:
![image](https://user-images.githubusercontent.com/3806031/150610821-b7ff3c93-bdd7-4119-9fa0-a6534e54442b.png)

We don't want it to render as Markdown, but rather the default (HTML I believe).

It also adds a "Steps to Reproduce" section that I forgot and marks a few sections as required.

Fixes N/A
