### PR TITLE
fix: update npm-dev.yaml

### DIFF
--- a/.github/workflows/npm-dev.yaml
+++ b/.github/workflows/npm-dev.yaml
@@ -24,4 +24,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TAG: "beta"
-          PR_NUMBER_AND_COMMIT_SHA: ${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
+          # Since this only runs on a merge into main, we can't use github.event.number
+          # so we instead use the word "beta" and the PR merge commit SHA
+          PR_NUMBER_AND_COMMIT_SHA: beta-${{ github.sha }}


### PR DESCRIPTION
I didn't think it through in my previous PR but since this workflow only runs on a merge into `main`, there is no PR number. So instead, we use the word "beta" and then we also have to grab a different SHA since there is no PR SHA.

Prevents this from happening again: https://www.npmjs.com/package/code-server/v/4.0.1--
https://github.com/coder/code-server/runs/4903294989?check_suite_focus=true#step:3:16

Fixes N/A
