### PR TITLE
refactor(ci): clean up npm workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,15 +177,6 @@ jobs:
           name: npm-package
           path: ./package.tar.gz
 
-      - name: Publish npm package with PR number and commit SHA
-        run: yarn publish:npm
-        env:
-          ENVIRONMENT: "development"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TAG: ${{ github.event.number }}
-          PR_NUMBER_AND_COMMIT_SHA: ${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
-
   # TODO: cache building yarn --production
   # possibly 2m30s of savings(?)
   # this requires refactoring our release scripts

--- a/.github/workflows/npm-beta.yaml
+++ b/.github/workflows/npm-beta.yaml
@@ -1,11 +1,11 @@
-name: Publish on npm and tag with PR number
+name: Publish on npm and tag with "beta"
 
 on:
   # Shows the manual trigger in GitHub UI
   # helpful as a back-up in case the GitHub Actions Workflow fails
   workflow_dispatch:
 
-  pull_request:
+  push:
     branches:
       - main
 
@@ -13,18 +13,17 @@ jobs:
   # NOTE: this job requires curl, jq and yarn
   # All of them are included in ubuntu-latest.
   npm:
-    # This environment "npm" requires someone from
-    # coder/code-server-reviewers to approve the PR before this job runs.
-    environment: npm
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
-      - name: Run ./ci/steps/publish-npm.sh
+      - name: Publish npm package and tag "beta"
         run: yarn publish:npm
         env:
-          ENVIRONMENT: "development"
+          ENVIRONMENT: "staging"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TAG: ${{ github.event.number }}
-          PR_NUMBER_AND_COMMIT_SHA: ${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
+          NPM_TAG: "beta"
+          # Since this only runs on a merge into main, we can't use github.event.number
+          # so we instead use the word "beta" and the PR merge commit SHA
+          PR_NUMBER_AND_COMMIT_SHA: beta-${{ github.sha }}

--- a/.github/workflows/npm-brew.yaml
+++ b/.github/workflows/npm-brew.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Publish npm package with PR number and commit SHA
+      - name: Publish npm package and tag with "latest"
         run: yarn publish:npm
         env:
           ENVIRONMENT: "production"


### PR DESCRIPTION
This extracts the publish on npm workflow from ci.yaml and adds a new workflow
called `npm-beta.yaml`.

Now we have three workflows that publish to npm.
- `npm-beta.yaml` only runs on pushes and merges into `main`
- `npm-dev.yaml` only runs on PRs into `main` with approval from
  code-server-reviewers team
- `npm-brew.yaml` only runs on releases

This should fix problems we had previously where anyone could open a PR and
publish under the code-server namespace. It also separates out the workflows
based on environment and when they should run.

I've also added the Environment `npm` which requires approval from one member of the code-server-reviewers team in order to run. This allows us to control which PRs publish to npm.

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes N/A
Fixes this issue: https://github.com/coder/code-server/runs/4903326846?check_suite_focus=true#step:14:13
