### PR TITLE
fix: make browser helper executable

### DIFF
--- a/ci/build/build-release.sh
+++ b/ci/build/build-release.sh
@@ -87,6 +87,7 @@ bundle_vscode() {
   # reason VS Code uses a different path in production).
   mkdir -p "$VSCODE_OUT_PATH/bin/helpers"
   rsync "$VSCODE_SRC_PATH/resources/server/bin/helpers/" "$VSCODE_OUT_PATH/bin/helpers"
+  chmod +x "$VSCODE_OUT_PATH/bin/helpers/browser.sh"
 
   # Add the commit and date and enable telemetry. This just makes telemetry
   # available; telemetry can still be disabled by flag or setting.


### PR DESCRIPTION
Surprisingly it does not come already executable like the dev-bin
scripts.

Much to my shame I did not actually test a release with the helper
change.  This time I did and can confirm it works.

Truly fixes https://github.com/coder/code-server/issues/4721

However while it no longer errors it does not actually open a browser
window...so I will look into that separately.