### PR TITLE
feat: Add support for imagePullSecrets to Helm chart

### DIFF
--- a/ci/helm-chart/templates/deployment.yaml
+++ b/ci/helm-chart/templates/deployment.yaml
@@ -21,10 +21,7 @@ spec:
         app.kubernetes.io/name: {{ include "code-server.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+      imagePullSecrets: {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- if .Values.hostnameOverride }}
       hostname: {{ .Values.hostnameOverride }}
       {{- end }}

--- a/ci/helm-chart/templates/deployment.yaml
+++ b/ci/helm-chart/templates/deployment.yaml
@@ -21,6 +21,10 @@ spec:
         app.kubernetes.io/name: {{ include "code-server.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if .Values.hostnameOverride }}
       hostname: {{ .Values.hostnameOverride }}
       {{- end }}

--- a/ci/helm-chart/values.yaml
+++ b/ci/helm-chart/values.yaml
@@ -9,7 +9,12 @@ image:
   tag: '4.0.2'
   pullPolicy: Always
 
+# Specifies one or more secrets to be used when pulling images from a
+# private container repository
+# https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry
 imagePullSecrets: []
+#  - name: registry-creds
+
 nameOverride: ""
 fullnameOverride: ""
 hostnameOverride: ""


### PR DESCRIPTION
<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes #
No issue created. Fix is very minor, but I can open an issue if needed.

Adds support for `imagePullSecrets`, which is defined as a top-level key in the values.yaml, but not previously used in the deployment template.
This PR adds support for `imagePullSecrets` into the deployment template, which is useful for users that may need to extend the default code-server image (installing additional language support, etc.) and as such may need to pull an image from a private container registry.

This should be a non-breaking change, as `imagePullSecrets` is defaulted to an empty array in the values.yaml