### PR TITLE
feat: Add support for ingressClassName in Helm Chart

### DIFF
--- a/ci/helm-chart/Chart.yaml
+++ b/ci/helm-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.1
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/ci/helm-chart/templates/ingress.yaml
+++ b/ci/helm-chart/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/ci/helm-chart/values.yaml
+++ b/ci/helm-chart/values.yaml
@@ -35,13 +35,12 @@ service:
 ingress:
   enabled: false
   #annotations:
-  #  kubernetes.io/ingress.class: nginx
   #  kubernetes.io/tls-acme: "true"
   #hosts:
   #  - host: code-server.example.loc
   #    paths:
   #      - /
-  #ingressClassName: nginx
+  ingressClassName:
   #tls:
   #  - secretName: code-server
   #    hosts:

--- a/ci/helm-chart/values.yaml
+++ b/ci/helm-chart/values.yaml
@@ -41,7 +41,7 @@ ingress:
   #  - host: code-server.example.loc
   #    paths:
   #      - /
-
+  #ingressClassName: nginx
   #tls:
   #  - secretName: code-server
   #    hosts:

--- a/ci/helm-chart/values.yaml
+++ b/ci/helm-chart/values.yaml
@@ -40,7 +40,7 @@ ingress:
   #  - host: code-server.example.loc
   #    paths:
   #      - /
-  ingressClassName:
+  ingressClassName: ""
   #tls:
   #  - secretName: code-server
   #    hosts:


### PR DESCRIPTION
Fixes #NA - No issue created due to minor nature of change. 

This adds an optional parameter to the ingress object for `ingressClassName` which is available in K8s 1.18+. More information on `ingressClassName` can be found [here](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/).

Please let me know if you need any more information or other changes. I did a minor version bump for the chart, but happy to remove that if needed. 