### PR TITLE
fix: Make dumb-init PID 1

### DIFF
--- a/ci/release-image/entrypoint.sh
+++ b/ci/release-image/entrypoint.sh
@@ -18,4 +18,4 @@ if [ "${DOCKER_USER-}" ]; then
   fi
 fi
 
-dumb-init /usr/bin/code-server "$@"
+exec dumb-init /usr/bin/code-server "$@"


### PR DESCRIPTION
dumb-init needs to run as PID 1, otherwise it doesn't do anything.
exec dumb-init so it takes over PID 1 once the entrypoint script is done.
