### PR TITLE
fix: skip docs/npm workflows on forks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,6 +184,9 @@ jobs:
     # This environment "npm" requires someone from
     # coder/code-server-reviewers to approve the PR before this job runs.
     environment: npm
+    # Only run if PR comes from base repo
+    # Reason: forks cannot access secrets and this will always fail
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -22,6 +22,9 @@ jobs:
     name: Docs preview
     runs-on: ubuntu-20.04
     environment: CI
+    # Only run if PR comes from base repo
+    # Reason: forks cannot access secrets and this will always fail
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1


### PR DESCRIPTION
## Summary
This PR adds a check to the `npm` and Docs Preview workflows to only run if base is coder/code-server repo. It will not run them on PRs from forks. 

### Changes
- add check to `preview` job in `docs-preview.yaml`
- add check to `npm` job in `ci.yaml`

### GitHub Settings Changes
- remove approval required for `npm` job

### Resources:
- https://github.community/t/how-to-detect-a-pull-request-from-a-fork/18363/3?u=jsjoeio
- https://github.community/t/make-secrets-available-to-builds-of-forks/16166/17

Fixes #4027
