### PR TITLE
docs: update sync vscode instructions

### DIFF
--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -1,6 +1,5 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 # Maintaining
 
 - [Team](#team)

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -1,5 +1,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 # Maintaining
 
 - [Team](#team)
@@ -223,7 +224,7 @@ The VS Code portion of code-server lives under [`coder/vscode`](https://github.c
 2. `git fetch upstream` - Fetch upstream (VS Code)'s latest branches
 3. `git merge upstream/release/1.64` - Merge it locally
    1. replace `1.64` with the version you're upgrading to
-   1. If there are merge conflicts, fix them locally
+   1. If there are merge conflicts, commit first, then fix them locally.
 4. Open a PR merging your branch (`vscode-update`) into `main` and add the code-server review team
 
 Ideally, our fork stays as close to upstream as possible. See the differences between our fork and upstream [here](https://github.com/microsoft/vscode/compare/main...coder:main).

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -220,8 +220,9 @@ This is currently automated with the release process.
 The VS Code portion of code-server lives under [`coder/vscode`](https://github.com/coder/vscode). To update VS Code for code-server, follow these steps:
 
 1. `git checkout -b vscode-update` - Create a new branch locally based off `main`
-2. `git fetch upstream` - Fetch upstream (VS Code)'s latest `main` branch
-3. `git merge upstream/main` - Merge it locally
+2. `git fetch upstream` - Fetch upstream (VS Code)'s latest branches
+3. `git merge upstream/release/1.64` - Merge it locally
+   1. replace `1.64` with the version you're upgrading to
    1. If there are merge conflicts, fix them locally
 4. Open a PR merging your branch (`vscode-update`) into `main` and add the code-server review team
 


### PR DESCRIPTION
Minor additions to the "Syncing with Upstream VS Code" docs.

Fixes N/A
