### PR TITLE
fix: state collision

### DIFF
--- a/test/e2e/codeServer.test.ts
+++ b/test/e2e/codeServer.test.ts
@@ -1,3 +1,5 @@
+import * as path from "path"
+import { promises as fs } from "fs"
 import { describe, test, expect } from "./baseFixture"
 
 describe("CodeServer", true, [], () => {
@@ -23,5 +25,12 @@ describe("CodeServer", true, [], () => {
   test("should show the Integrated Terminal", async ({ codeServerPage }) => {
     await codeServerPage.focusTerminal()
     expect(await codeServerPage.page.isVisible("#terminal")).toBe(true)
+  })
+
+  test("should open a file", async ({ codeServerPage }) => {
+    const dir = await codeServerPage.dir()
+    const file = path.join(dir, "foo")
+    await fs.writeFile(file, "bar")
+    await codeServerPage.openFile(file)
   })
 })

--- a/test/e2e/codeServer.test.ts
+++ b/test/e2e/codeServer.test.ts
@@ -28,14 +28,14 @@ describe("CodeServer", true, [], () => {
   })
 
   test("should open a file", async ({ codeServerPage }) => {
-    const dir = await codeServerPage.dir()
+    const dir = await codeServerPage.workspaceDir
     const file = path.join(dir, "foo")
     await fs.writeFile(file, "bar")
     await codeServerPage.openFile(file)
   })
 
   test("should not share state with other paths", async ({ codeServerPage }) => {
-    const dir = await codeServerPage.dir()
+    const dir = await codeServerPage.workspaceDir
     const file = path.join(dir, "foo")
     await fs.writeFile(file, "bar")
 

--- a/test/e2e/codeServer.test.ts
+++ b/test/e2e/codeServer.test.ts
@@ -33,4 +33,25 @@ describe("CodeServer", true, [], () => {
     await fs.writeFile(file, "bar")
     await codeServerPage.openFile(file)
   })
+
+  test("should not share state with other paths", async ({ codeServerPage }) => {
+    const dir = await codeServerPage.dir()
+    const file = path.join(dir, "foo")
+    await fs.writeFile(file, "bar")
+
+    await codeServerPage.openFile(file)
+
+    // If we reload now VS Code will be unable to save the state changes so wait
+    // until those have been written to the database.  It flushes every five
+    // seconds so we need to wait at least that long.
+    await codeServerPage.page.waitForTimeout(5500)
+
+    // The tab should re-open on refresh.
+    await codeServerPage.page.reload()
+    await codeServerPage.waitForTab(file)
+
+    // The tab should not re-open on a different path.
+    await codeServerPage.setup(true, "/vscode")
+    expect(await codeServerPage.tabIsVisible(file)).toBe(false)
+  })
 })

--- a/test/e2e/codeServer.test.ts
+++ b/test/e2e/codeServer.test.ts
@@ -1,5 +1,5 @@
-import * as path from "path"
 import { promises as fs } from "fs"
+import * as path from "path"
 import { describe, test, expect } from "./baseFixture"
 
 describe("CodeServer", true, [], () => {

--- a/test/e2e/models/CodeServer.ts
+++ b/test/e2e/models/CodeServer.ts
@@ -297,7 +297,7 @@ export class CodeServerPage {
    */
   async openFile(file: string) {
     await this.navigateMenus(["File", "Open File"])
-    await this.navigatePicker([path.basename(file)])
+    await this.navigateQuickInput([path.basename(file)])
     await this.waitForTab(file)
   }
 
@@ -427,9 +427,10 @@ export class CodeServerPage {
   }
 
   /**
-   * Navigate through a currently opened picker, retrying on failure.
+   * Navigate through a currently opened "quick input" widget, retrying on
+   * failure.
    */
-  async navigatePicker(items: string[]): Promise<void> {
+  async navigateQuickInput(items: string[]): Promise<void> {
     await this.navigateItems(items, ".quick-input-widget")
   }
 

--- a/test/e2e/models/CodeServer.ts
+++ b/test/e2e/models/CodeServer.ts
@@ -37,7 +37,7 @@ export class CodeServer {
   private process: Promise<CodeServerProcess> | undefined
   public readonly logger: Logger
   private closed = false
-  private workspaceDir: Promise<string> | undefined
+  private _workspaceDir: Promise<string> | undefined
 
   constructor(name: string, private readonly codeServerArgs: string[]) {
     this.logger = logger.named(name)
@@ -55,18 +55,21 @@ export class CodeServer {
     return address
   }
 
-  async dir(): Promise<string> {
-    if (!this.workspaceDir) {
-      this.workspaceDir = tmpdir(workspaceDir)
+  /**
+   * The workspace directory code-server opens with.
+   */
+  get workspaceDir(): Promise<string> {
+    if (!this._workspaceDir) {
+      this._workspaceDir = tmpdir(workspaceDir)
     }
-    return this.workspaceDir
+    return this._workspaceDir
   }
 
   /**
    * Create a random workspace and seed it with settings.
    */
   private async createWorkspace(): Promise<string> {
-    const dir = await this.dir()
+    const dir = await this.workspaceDir
     await fs.mkdir(path.join(dir, "User"))
     await fs.writeFile(
       path.join(dir, "User/settings.json"),
@@ -198,8 +201,11 @@ export class CodeServerPage {
     return this.codeServer.address()
   }
 
-  dir() {
-    return this.codeServer.dir()
+  /**
+   * The workspace directory code-server opens with.
+   */
+  get workspaceDir() {
+    return this.codeServer.workspaceDir
   }
 
   /**

--- a/test/e2e/models/CodeServer.ts
+++ b/test/e2e/models/CodeServer.ts
@@ -203,11 +203,11 @@ export class CodeServerPage {
   }
 
   /**
-   * Navigate to code-server.
+   * Navigate to a code-server endpoint.  By default go to the root.
    */
-  async navigate() {
-    const address = await this.codeServer.address()
-    await this.page.goto(address, { waitUntil: "networkidle" })
+  async navigate(path: string = "/") {
+    const to = new URL(path, await this.codeServer.address())
+    await this.page.goto(to.toString(), { waitUntil: "networkidle" })
   }
 
   /**
@@ -306,6 +306,13 @@ export class CodeServerPage {
    */
   async waitForTab(file: string): Promise<void> {
     return this.page.waitForSelector(`.tab :text("${path.basename(file)}")`)
+  }
+
+  /**
+   * See if the specified tab is open.
+   */
+  async tabIsVisible(file: string): Promise<void> {
+    return this.page.isVisible(`.tab :text("${path.basename(file)}")`)
   }
 
   /**
@@ -426,8 +433,8 @@ export class CodeServerPage {
    *
    * It is recommended to run setup before using this model in any tests.
    */
-  async setup(authenticated: boolean) {
-    await this.navigate()
+  async setup(authenticated: boolean, endpoint = "/") {
+    await this.navigate(endpoint)
     // If we aren't authenticated we'll see a login page so we can't wait until
     // the editor is ready.
     if (authenticated) {

--- a/test/e2e/models/CodeServer.ts
+++ b/test/e2e/models/CodeServer.ts
@@ -205,7 +205,7 @@ export class CodeServerPage {
   /**
    * Navigate to a code-server endpoint.  By default go to the root.
    */
-  async navigate(path: string = "/") {
+  async navigate(path = "/") {
     const to = new URL(path, await this.codeServer.address())
     await this.page.goto(to.toString(), { waitUntil: "networkidle" })
   }
@@ -360,10 +360,12 @@ export class CodeServerPage {
      * try again.
      */
     const navigate = async (ctx: Context) => {
-      const steps: Array<{fn: () => Promise<unknown>, name: string}> = [{
-        fn: () => this.page.waitForSelector(`${selector}:focus-within`),
-        name: "focus",
-      }]
+      const steps: Array<{ fn: () => Promise<unknown>; name: string }> = [
+        {
+          fn: () => this.page.waitForSelector(`${selector}:focus-within`),
+          name: "focus",
+        },
+      ]
 
       for (const item of items) {
         // Normally these will wait for the item to be visible and then execute
@@ -373,10 +375,22 @@ export class CodeServerPage {
         // if the old promise clicks logout before the new one can). By
         // splitting them into two steps each we can cancel before running the
         // action.
-        steps.push({fn: () => this.page.hover(`${selector} :text("${item}")`, { trial: true }), name: `${item}:hover:trial`})
-        steps.push({fn: () => this.page.hover(`${selector} :text("${item}")`, { force: true }), name: `${item}:hover:force`})
-        steps.push({fn: () => this.page.click(`${selector} :text("${item}")`, { trial: true }), name: `${item}:click:trial`})
-        steps.push({fn: () => this.page.click(`${selector} :text("${item}")`, { force: true }), name: `${item}:click:force`})
+        steps.push({
+          fn: () => this.page.hover(`${selector} :text("${item}")`, { trial: true }),
+          name: `${item}:hover:trial`,
+        })
+        steps.push({
+          fn: () => this.page.hover(`${selector} :text("${item}")`, { force: true }),
+          name: `${item}:hover:force`,
+        })
+        steps.push({
+          fn: () => this.page.click(`${selector} :text("${item}")`, { trial: true }),
+          name: `${item}:click:trial`,
+        })
+        steps.push({
+          fn: () => this.page.click(`${selector} :text("${item}")`, { force: true }),
+          name: `${item}:click:force`,
+        })
       }
 
       for (const step of steps) {

--- a/test/e2e/models/CodeServer.ts
+++ b/test/e2e/models/CodeServer.ts
@@ -205,8 +205,8 @@ export class CodeServerPage {
   /**
    * Navigate to a code-server endpoint.  By default go to the root.
    */
-  async navigate(path = "/") {
-    const to = new URL(path, await this.codeServer.address())
+  async navigate(endpoint = "/") {
+    const to = new URL(endpoint, await this.codeServer.address())
     await this.page.goto(to.toString(), { waitUntil: "networkidle" })
   }
 

--- a/vendor/package.json
+++ b/vendor/package.json
@@ -7,6 +7,6 @@
     "postinstall": "./postinstall.sh"
   },
   "devDependencies": {
-    "code-oss-dev": "coder/vscode#96e241330d9c44b64897c1e5031e00aa894103db"
+    "code-oss-dev": "coder/vscode#6337ee490d16b7dfd8854d22c998f58d6cd21ef5"
   }
 }

--- a/vendor/yarn.lock
+++ b/vendor/yarn.lock
@@ -274,9 +274,9 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-code-oss-dev@coder/vscode#96e241330d9c44b64897c1e5031e00aa894103db:
+code-oss-dev@coder/vscode#6337ee490d16b7dfd8854d22c998f58d6cd21ef5:
   version "1.63.0"
-  resolved "https://codeload.github.com/coder/vscode/tar.gz/96e241330d9c44b64897c1e5031e00aa894103db"
+  resolved "https://codeload.github.com/coder/vscode/tar.gz/6337ee490d16b7dfd8854d22c998f58d6cd21ef5"
   dependencies:
     "@microsoft/applicationinsights-web" "^2.6.4"
     "@parcel/watcher" "2.0.3"


### PR DESCRIPTION
VS Code names their databases after the workspace but if two workspaces share the same path (for example if they are on different virtual machines) but they share the same domain (since IndexedDB is scoped to domain) then those two states will have a naming collision.

Blocked on https://github.com/coder/vscode/pull/46.