### PR TITLE
fix: Pin express to 5.0.0-alpha.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.5",
     "env-paths": "^2.2.0",
-    "express": "^5.0.0-alpha.8",
+    "express": "5.0.0-alpha.8",
     "http-proxy": "^1.18.0",
     "httpolyglot": "^0.1.2",
     "js-yaml": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1729,7 +1729,7 @@ execall@^2.0.0:
   dependencies:
     clone-regexp "^2.1.0"
 
-express@^5.0.0-alpha.8:
+express@5.0.0-alpha.8:
   version "5.0.0-alpha.8"
   resolved "https://registry.yarnpkg.com/express/-/express-5.0.0-alpha.8.tgz#b9dd3a568eab791e3391db47f9e6ab91e61b13fe"
   integrity sha512-PL8wTLgaNOiq7GpXt187/yWHkrNSfbr4H0yy+V0fpqJt5wpUzBi9DprAkwGKBFOqWHylJ8EyPy34V5u9YArfng==


### PR DESCRIPTION
Fixes #4900

Since [`express@5.0.0-beta.1` was released on 2022-02-14](https://www.npmjs.com/package/express/v/5.0.0-beta.1), any new install was bumped to use that version. That's because [the way `semver`'s caret works, and how `beta` > `alpha`](https://github.com/npm/node-semver#prerelease-tags). And it just so happens that there's a breaking change in there apparently.

When developing, the `yarn.lock` file is used, which itself was [pinning to `express@5.0.0-alpha.8` ](https://github.com/coder/code-server/blob/a989e0c3879e5a7cd52011a4de929e4d1e3faad3/yarn.lock#L1732)which led to everything working well.

But when a package gets published, [the lockfile gets ignored by `yarn publish`](https://classic.yarnpkg.com/lang/en/docs/yarn-lock/#toc-check-into-source-control) (see the missing `yarn.lock` in https://unpkg.com/browse/code-server@4.0.2/). That being said, even if present, it would still be irrelevant, because when installing code-server globally, it's still considered of a dependency of a global package. And the lockfiles from dependencies also get ignored when installing them. (See [this Libraries vs Applications section](https://classic.yarnpkg.com/blog/2016/11/24/lockfiles-for-all/) for the reasons why).

----

I ran the release manually, and then installed the `release.tar.gz` package - and it all worked as expected 🎉