### PR TITLE
feat: add version string functions to constants

### DIFF
--- a/src/node/constants.ts
+++ b/src/node/constants.ts
@@ -32,7 +32,7 @@ export const httpProxyUri =
 // getVersionString returns a human-readable version string suitable
 // for outputting to the console.
 export function getVersionString(): string {
-  return [ version, commit ].join(" ")
+  return [version, commit].join(" ")
 }
 
 // getVersionJsonString returns a machine-readable version string

--- a/src/node/constants.ts
+++ b/src/node/constants.ts
@@ -23,7 +23,24 @@ export const version = pkg.version || "development"
 export const commit = pkg.commit || "development"
 export const rootPath = path.resolve(__dirname, "../..")
 export const vsRootPath = path.join(rootPath, "vendor/modules/code-oss-dev")
+export const codeVersion = require(path.join(vsRootPath, "package.json")).version
 export const tmpdir = path.join(os.tmpdir(), "code-server")
 export const isDevMode = commit === "development"
 export const httpProxyUri =
   process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy
+
+// getVersionString returns a human-readable version string suitable
+// for outputting to the console.
+export function getVersionString(): string {
+  return [ version, commit ].join(" ")
+}
+
+// getVersionJsonString returns a machine-readable version string
+// suitable for outputting to the console.
+export function getVersionJsonString(): string {
+  return JSON.stringify({
+    codeServer: version,
+    commit,
+    vscode: codeVersion,
+  })
+}

--- a/src/node/constants.ts
+++ b/src/node/constants.ts
@@ -23,7 +23,7 @@ export const version = pkg.version || "development"
 export const commit = pkg.commit || "development"
 export const rootPath = path.resolve(__dirname, "../..")
 export const vsRootPath = path.join(rootPath, "vendor/modules/code-oss-dev")
-export const codeVersion = require(path.join(vsRootPath, "package.json")).version
+export const codeVersion = require(path.join(vsRootPath, "package.json")).version || "development"
 export const tmpdir = path.join(os.tmpdir(), "code-server")
 export const isDevMode = commit === "development"
 export const httpProxyUri =

--- a/src/node/constants.ts
+++ b/src/node/constants.ts
@@ -17,26 +17,31 @@ export function getPackageJson(relativePath: string): JSONSchemaForNPMPackageJso
 }
 
 const pkg = getPackageJson("../../package.json")
+const codePkg = getPackageJson("../../vendor/modules/code-oss-dev/package.json")
 
 export const pkgName = pkg.name || "code-server"
 export const version = pkg.version || "development"
 export const commit = pkg.commit || "development"
 export const rootPath = path.resolve(__dirname, "../..")
 export const vsRootPath = path.join(rootPath, "vendor/modules/code-oss-dev")
-export const codeVersion = require(path.join(vsRootPath, "package.json")).version || "development"
+export const codeVersion = codePkg.version || "development"
 export const tmpdir = path.join(os.tmpdir(), "code-server")
 export const isDevMode = commit === "development"
 export const httpProxyUri =
   process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy
 
-// getVersionString returns a human-readable version string suitable
-// for outputting to the console.
+/**
+ * getVersionString returns a human-readable version string suitable
+ * for outputting to the console.
+ */
 export function getVersionString(): string {
   return [version, commit].join(" ")
 }
 
-// getVersionJsonString returns a machine-readable version string
-// suitable for outputting to the console.
+/**
+ * getVersionJsonString returns a machine-readable version string
+ * suitable for outputting to the console.
+ */
 export function getVersionJsonString(): string {
   return JSON.stringify({
     codeServer: version,

--- a/test/unit/node/constants.test.ts
+++ b/test/unit/node/constants.test.ts
@@ -119,5 +119,18 @@ describe("constants", () => {
     it("commit should return 'development'", () => {
       expect(constants.commit).toBe("development")
     })
+
+    it("should return a human-readable version string", () => {
+      // this string is not super useful
+      expect(constants.getVersionString()).toStrictEqual("development development")
+    })
+
+    it("should return a machine-readable version string", () => {
+      expect(constants.getVersionJsonString()).toStrictEqual(JSON.stringify({
+        codeServer: "development",
+        commit: "development",
+        vscode: "development",
+      }))
+    })
   })
 })

--- a/test/unit/node/constants.test.ts
+++ b/test/unit/node/constants.test.ts
@@ -64,11 +64,13 @@ describe("constants", () => {
     })
 
     it("should return a machine-readable version string", () => {
-      expect(constants.getVersionJsonString()).toStrictEqual(JSON.stringify({
-        codeServer: mockPackageJson.version,
-        commit: mockPackageJson.commit,
-        vscode: mockCodePackageJson.version,
-      }))
+      expect(constants.getVersionJsonString()).toStrictEqual(
+        JSON.stringify({
+          codeServer: mockPackageJson.version,
+          commit: mockPackageJson.commit,
+          vscode: mockCodePackageJson.version,
+        }),
+      )
     })
 
     describe("getPackageJson", () => {
@@ -126,11 +128,13 @@ describe("constants", () => {
     })
 
     it("should return a machine-readable version string", () => {
-      expect(constants.getVersionJsonString()).toStrictEqual(JSON.stringify({
-        codeServer: "development",
-        commit: "development",
-        vscode: "development",
-      }))
+      expect(constants.getVersionJsonString()).toStrictEqual(
+        JSON.stringify({
+          codeServer: "development",
+          commit: "development",
+          vscode: "development",
+        }),
+      )
     })
   })
 })

--- a/test/unit/node/constants.test.ts
+++ b/test/unit/node/constants.test.ts
@@ -1,5 +1,6 @@
 import { logger } from "@coder/logger"
 import { mockLogger } from "../../utils/helpers"
+import * as semver from "semver"
 
 describe("constants", () => {
   let constants: typeof import("../../../src/node/constants")
@@ -13,9 +14,15 @@ describe("constants", () => {
       commit: "f6b2be2838f4afb217c2fd8f03eafedd8d55ef9b",
     }
 
+    const mockCodePackageJson = {
+      name: "mock-code-oss-dev",
+      version: "1.2.3",
+    }
+
     beforeAll(() => {
       mockLogger()
       jest.mock("../../../package.json", () => mockPackageJson, { virtual: true })
+      jest.mock("../../../vendor/modules/code-oss-dev/package.json", () => mockCodePackageJson, { virtual: true })
       constants = require("../../../src/node/constants")
     })
 
@@ -24,12 +31,44 @@ describe("constants", () => {
       jest.resetModules()
     })
 
+    it("should provide the package name", () => {
+      expect(constants.pkgName).toBe(mockPackageJson.name)
+    })
+
     it("should provide the commit", () => {
       expect(constants.commit).toBe(mockPackageJson.commit)
     })
 
     it("should return the package.json version", () => {
       expect(constants.version).toBe(mockPackageJson.version)
+
+      // Ensure the version is parseable as semver and equal
+      const actual = semver.parse(constants.version)
+      const expected = semver.parse(mockPackageJson.version)
+      expect(actual).toBeTruthy()
+      expect(actual).toStrictEqual(expected)
+    })
+
+    it("should include embedded Code version information", () => {
+      expect(constants.codeVersion).toBe(mockCodePackageJson.version)
+
+      // Ensure the version is parseable as semver and equal
+      const actual = semver.parse(constants.codeVersion)
+      const expected = semver.parse(mockCodePackageJson.version)
+      expect(actual).toBeTruthy()
+      expect(actual).toStrictEqual(expected)
+    })
+
+    it("should return a human-readable version string", () => {
+      expect(constants.getVersionString()).toStrictEqual(`${mockPackageJson.version} ${mockPackageJson.commit}`)
+    })
+
+    it("should return a machine-readable version string", () => {
+      expect(constants.getVersionJsonString()).toStrictEqual(JSON.stringify({
+        codeServer: mockPackageJson.version,
+        commit: mockPackageJson.commit,
+        vscode: mockCodePackageJson.version,
+      }))
     })
 
     describe("getPackageJson", () => {
@@ -47,6 +86,9 @@ describe("constants", () => {
         // so to get the root package.json we need to use ../../
         const packageJson = constants.getPackageJson("../../package.json")
         expect(packageJson).toStrictEqual(mockPackageJson)
+
+        const codePackageJson = constants.getPackageJson("../../vendor/modules/code-oss-dev/package.json")
+        expect(codePackageJson).toStrictEqual(mockCodePackageJson)
       })
     })
   })
@@ -55,9 +97,13 @@ describe("constants", () => {
     const mockPackageJson = {
       name: "mock-code-server",
     }
+    const mockCodePackageJson = {
+      name: "mock-code-oss-dev",
+    }
 
     beforeAll(() => {
       jest.mock("../../../package.json", () => mockPackageJson, { virtual: true })
+      jest.mock("../../../vendor/modules/code-oss-dev/package.json", () => mockCodePackageJson, { virtual: true })
       constants = require("../../../src/node/constants")
     })
 
@@ -69,6 +115,7 @@ describe("constants", () => {
     it("version should return 'development'", () => {
       expect(constants.version).toBe("development")
     })
+
     it("commit should return 'development'", () => {
       expect(constants.commit).toBe("development")
     })


### PR DESCRIPTION
Introduce helper functions for getting human- and machine-readable
version strings from the constants package, and cover it in unit
tests.

This is a first step to resolving #4874.
