### PR TITLE
feat: cli arg for file permission of socket

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -56,6 +56,7 @@ export interface UserProvidedArgs {
   open?: boolean
   "bind-addr"?: string
   socket?: string
+  "socket-mode"?: string
   version?: boolean
   "proxy-domain"?: string[]
   "reuse-window"?: boolean
@@ -175,6 +176,7 @@ const options: Options<Required<UserProvidedArgs>> = {
   port: { type: "number", description: "" },
 
   socket: { type: "string", path: true, description: "Path to a socket (bind-addr will be ignored)." },
+  "socket-mode": { type: "string", description: "File mode of the socket." },
   version: { type: "boolean", short: "v", description: "Display version information." },
   _: { type: "string[]" },
 
@@ -513,6 +515,7 @@ export async function setDefaults(cliArgs: UserProvidedArgs, configArgs?: Config
     args.host = "localhost"
     args.port = 0
     args.socket = undefined
+    args["socket-mode"] = undefined
     args.cert = undefined
     args.auth = AuthType.None
   }

--- a/test/unit/node/app.test.ts
+++ b/test/unit/node/app.test.ts
@@ -107,6 +107,18 @@ describe("createApp", () => {
     app.dispose()
   })
 
+  it("should change the file mode of a socket", async () => {
+    const defaultArgs = await setDefaults({
+      socket: tmpFilePath,
+      "socket-mode": "777",
+    })
+
+    const app = await createApp(defaultArgs)
+
+    expect((await promises.stat(tmpFilePath)).mode & 0o777).toBe(0o777)
+    app.dispose()
+  })
+
   it("should create an https server if args.cert exists", async () => {
     const testCertificate = await generateCertificate("localhost")
     const cert = new OptionalString(testCertificate.cert)

--- a/test/unit/node/cli.test.ts
+++ b/test/unit/node/cli.test.ts
@@ -73,6 +73,8 @@ describe("parser", () => {
 
           "--socket=mumble",
 
+          "--socket-mode=777",
+
           "3",
 
           ["--user-data-dir", "path/to/user/dir"],
@@ -110,6 +112,7 @@ describe("parser", () => {
       open: true,
       port: 8081,
       socket: path.resolve("mumble"),
+      "socket-mode": "777",
       verbose: true,
       version: true,
       "bind-addr": "192.169.0.1:8080",
@@ -269,7 +272,9 @@ describe("parser", () => {
   })
 
   it("should override with --link", async () => {
-    const args = parse("--cert test --cert-key test --socket test --host 0.0.0.0 --port 8888 --link test".split(" "))
+    const args = parse(
+      "--cert test --cert-key test --socket test --socket-mode 777 --host 0.0.0.0 --port 8888 --link test".split(" "),
+    )
     const defaultArgs = await setDefaults(args)
     expect(defaultArgs).toEqual({
       ...defaults,
@@ -282,6 +287,7 @@ describe("parser", () => {
       cert: undefined,
       "cert-key": path.resolve("test"),
       socket: undefined,
+      "socket-mode": undefined,
     })
   })
 


### PR DESCRIPTION
Fixes #1466

Add a cli option `--socket-permission`, and set file mode accordingly when listening a socket.