### PR TITLE
feat: add version of Code OSS to output

### DIFF
--- a/src/node/constants.ts
+++ b/src/node/constants.ts
@@ -35,7 +35,7 @@ export const httpProxyUri =
  * for outputting to the console.
  */
 export function getVersionString(): string {
-  return [version, commit, "Code", codeVersion].join(" ")
+  return [version, commit, "with Code", codeVersion].join(" ")
 }
 
 /**

--- a/src/node/constants.ts
+++ b/src/node/constants.ts
@@ -35,7 +35,7 @@ export const httpProxyUri =
  * for outputting to the console.
  */
 export function getVersionString(): string {
-  return [version, commit].join(" ")
+  return [version, commit, "Code", codeVersion].join(" ")
 }
 
 /**

--- a/src/node/entry.ts
+++ b/src/node/entry.ts
@@ -1,6 +1,6 @@
 import { logger } from "@coder/logger"
 import { optionDescriptions, parse, readConfigFile, setDefaults, shouldOpenInExistingInstance } from "./cli"
-import { commit, version } from "./constants"
+import { getVersionString, getVersionJsonString } from "./constants"
 import { openInExistingInstance, runCodeServer, runVsCodeCli, shouldSpawnCliProcess } from "./main"
 import { isChild, wrapper } from "./wrapper"
 
@@ -24,7 +24,7 @@ async function entry(): Promise<void> {
   const args = await setDefaults(cliArgs, configArgs)
 
   if (args.help) {
-    console.log("code-server", version, commit)
+    console.log("code-server", getVersionString())
     console.log("")
     console.log(`Usage: code-server [options] [path]`)
     console.log(`    - Opening a directory: code-server ./path/to/your/project`)
@@ -39,15 +39,9 @@ async function entry(): Promise<void> {
 
   if (args.version) {
     if (args.json) {
-      console.log(
-        JSON.stringify({
-          codeServer: version,
-          commit,
-          vscode: require("../../vendor/modules/code-oss-dev/package.json").version,
-        }),
-      )
+      console.log(getVersionJsonString())
     } else {
-      console.log(version, commit)
+      console.log(getVersionString())
     }
     return
   }

--- a/test/unit/node/constants.test.ts
+++ b/test/unit/node/constants.test.ts
@@ -60,7 +60,9 @@ describe("constants", () => {
     })
 
     it("should return a human-readable version string", () => {
-      expect(constants.getVersionString()).toStrictEqual(`${mockPackageJson.version} ${mockPackageJson.commit} Code ${mockCodePackageJson.version}`)
+      expect(constants.getVersionString()).toStrictEqual(
+        `${mockPackageJson.version} ${mockPackageJson.commit} Code ${mockCodePackageJson.version}`,
+      )
     })
 
     it("should return a machine-readable version string", () => {

--- a/test/unit/node/constants.test.ts
+++ b/test/unit/node/constants.test.ts
@@ -60,7 +60,7 @@ describe("constants", () => {
     })
 
     it("should return a human-readable version string", () => {
-      expect(constants.getVersionString()).toStrictEqual(`${mockPackageJson.version} ${mockPackageJson.commit}`)
+      expect(constants.getVersionString()).toStrictEqual(`${mockPackageJson.version} ${mockPackageJson.commit} Code ${mockCodePackageJson.version}`)
     })
 
     it("should return a machine-readable version string", () => {
@@ -124,7 +124,7 @@ describe("constants", () => {
 
     it("should return a human-readable version string", () => {
       // this string is not super useful
-      expect(constants.getVersionString()).toStrictEqual("development development")
+      expect(constants.getVersionString()).toStrictEqual("development development Code development")
     })
 
     it("should return a machine-readable version string", () => {

--- a/test/unit/node/constants.test.ts
+++ b/test/unit/node/constants.test.ts
@@ -61,7 +61,7 @@ describe("constants", () => {
 
     it("should return a human-readable version string", () => {
       expect(constants.getVersionString()).toStrictEqual(
-        `${mockPackageJson.version} ${mockPackageJson.commit} Code ${mockCodePackageJson.version}`,
+        `${mockPackageJson.version} ${mockPackageJson.commit} with Code ${mockCodePackageJson.version}`,
       )
     })
 

--- a/test/unit/node/constants.test.ts
+++ b/test/unit/node/constants.test.ts
@@ -126,7 +126,7 @@ describe("constants", () => {
 
     it("should return a human-readable version string", () => {
       // this string is not super useful
-      expect(constants.getVersionString()).toStrictEqual("development development Code development")
+      expect(constants.getVersionString()).toStrictEqual("development development with Code development")
     })
 
     it("should return a machine-readable version string", () => {


### PR DESCRIPTION
Show the bundled version of Code OSS in the text-based output
for --version and --help, in addition to the JSON output
(--version --json)

Closes: #4874

---

Help output:

```
$ node . --help
code-server 4.0.2 development with Code 1.63.0

Usage: code-server [options] [path]
    - Opening a directory: code-server ./path/to/your/project
    - Opening a saved workspace: code-server ./path/to/your/project.code-workspace
```

Output of --version:

```
$ node . --version
4.0.2 development with Code 1.63.0
```

Output of --version --json:

```
$ node . --version --json
{"codeServer":"4.0.2","commit":"development","vscode":"1.63.0"}
```