### PR TITLE
refactor: remove folder/workspace from vsCodeCliArgs

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -3,15 +3,7 @@ import { promises as fs } from "fs"
 import yaml from "js-yaml"
 import * as os from "os"
 import * as path from "path"
-import {
-  canConnect,
-  generateCertificate,
-  generatePassword,
-  humanPath,
-  paths,
-  isNodeJSErrnoException,
-  isFile,
-} from "./util"
+import { canConnect, generateCertificate, generatePassword, humanPath, paths, isNodeJSErrnoException } from "./util"
 
 const DEFAULT_SOCKET_PATH = path.join(os.tmpdir(), "vscode-ipc")
 
@@ -448,7 +440,7 @@ export interface DefaultedArgs extends ConfigArgs {
   "extensions-dir": string
   "user-data-dir": string
   /* Positional arguments. */
-  _: []
+  _: string[] | []
 }
 
 /**

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -770,25 +770,9 @@ export const shouldOpenInExistingInstance = async (args: UserProvidedArgs): Prom
  * Convert our arguments to VS Code server arguments.
  */
 export const toVsCodeArgs = async (args: DefaultedArgs): Promise<CodeServerLib.ServerParsedArgs> => {
-  let workspace = ""
-  let folder = ""
-  if (args._.length) {
-    const lastEntry = path.resolve(args._[args._.length - 1])
-    const entryIsFile = await isFile(lastEntry)
-    if (entryIsFile && path.extname(lastEntry) === ".code-workspace") {
-      workspace = lastEntry
-    } else if (!entryIsFile) {
-      folder = lastEntry
-    }
-    // Otherwise it is a regular file.  Spawning VS Code with a file is not yet
-    // supported but it can be done separately after code-server spawns.
-  }
-
   return {
     "connection-token": "0000",
     ...args,
-    workspace,
-    folder,
     "accept-server-license-terms": true,
     /** Type casting. */
     help: !!args.help,

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -440,7 +440,7 @@ export interface DefaultedArgs extends ConfigArgs {
   "extensions-dir": string
   "user-data-dir": string
   /* Positional arguments. */
-  _: string[] | []
+  _: string[]
 }
 
 /**

--- a/src/node/routes/vscode.ts
+++ b/src/node/routes/vscode.ts
@@ -57,14 +57,12 @@ export class CodeServerRouteWrapper {
           workspace: lastOpened.workspace,
         })
       } else if (req.args._.length > 0) {
-        if (req.args._.length) {
-          const lastEntry = path.resolve(req.args._[req.args._.length - 1])
-          const entryIsFile = await isFile(lastEntry)
-          if (entryIsFile && path.extname(lastEntry) === ".code-workspace") {
-            workspace = lastEntry
-          } else if (!entryIsFile) {
-            folder = lastEntry
-          }
+        const lastEntry = path.resolve(req.args._[req.args._.length - 1])
+        const entryIsFile = await isFile(lastEntry)
+        if (entryIsFile && path.extname(lastEntry) === ".code-workspace") {
+          workspace = lastEntry
+        } else if (!entryIsFile) {
+          folder = lastEntry
         }
       }
       return redirect(req, res, to, {

--- a/src/node/routes/vscode.ts
+++ b/src/node/routes/vscode.ts
@@ -42,7 +42,7 @@ export class CodeServerRouteWrapper {
       const lastOpened = settings.query || {}
       // This flag disables the last opened behavior
       const IGNORE_LAST_OPENED = req.args["ignore-last-opened"]
-      const HAS_LAST_OPENED_FOLDER_OR_WORKSPACE = (!WORKSPACE_WAS_CLOSED && lastOpened.folder) || lastOpened.workspace
+      const HAS_LAST_OPENED_FOLDER_OR_WORKSPACE = lastOpened.folder || lastOpened.workspace
       const HAS_FOLDER_OR_WORKSPACE_FROM_CLI = req.args._.length > 0
       const to = self(req)
 

--- a/src/node/routes/vscode.ts
+++ b/src/node/routes/vscode.ts
@@ -49,11 +49,6 @@ export class CodeServerRouteWrapper {
       let folder = undefined
       let workspace = undefined
 
-      if (WORKSPACE_WAS_CLOSED) {
-        delete lastOpened.folder
-        delete lastOpened.workspace
-      }
-
       // Redirect to the last folder/workspace if nothing else is opened.
       if (HAS_LAST_OPENED_FOLDER_OR_WORKSPACE && !IGNORE_LAST_OPENED) {
         folder = lastOpened.folder

--- a/src/node/routes/vscode.ts
+++ b/src/node/routes/vscode.ts
@@ -28,7 +28,7 @@ export class CodeServerRouteWrapper {
     const isAuthenticated = await authenticated(req)
     const NO_FOLDER_OR_WORKSPACE_QUERY = !req.query.folder && !req.query.workspace
     // Ew means the workspace was closed so clear the last folder/workspace.
-    const WORKSPACE_WAS_CLOSED = req.query.ew
+    const FOLDER_OR_WORKSPACE_WAS_CLOSED = req.query.ew
 
     if (!isAuthenticated) {
       const to = self(req)
@@ -37,7 +37,7 @@ export class CodeServerRouteWrapper {
       })
     }
 
-    if (NO_FOLDER_OR_WORKSPACE_QUERY && !WORKSPACE_WAS_CLOSED) {
+    if (NO_FOLDER_OR_WORKSPACE_QUERY && !FOLDER_OR_WORKSPACE_WAS_CLOSED) {
       const settings = await req.settings.read()
       const lastOpened = settings.query || {}
       // This flag disables the last opened behavior

--- a/src/node/routes/vscode.ts
+++ b/src/node/routes/vscode.ts
@@ -52,10 +52,8 @@ export class CodeServerRouteWrapper {
         (lastOpened.folder || lastOpened.workspace) &&
         !req.args["ignore-last-opened"] // This flag disables this behavior.
       ) {
-        return redirect(req, res, to, {
-          folder: lastOpened.folder,
-          workspace: lastOpened.workspace,
-        })
+        folder = lastOpened.folder
+        workspace = lastOpened.workspace
       } else if (req.args._.length > 0) {
         const lastEntry = path.resolve(req.args._[req.args._.length - 1])
         const entryIsFile = await isFile(lastEntry)

--- a/src/node/routes/vscode.ts
+++ b/src/node/routes/vscode.ts
@@ -34,19 +34,19 @@ export class CodeServerRouteWrapper {
       })
     }
 
-    const settings = await req.settings.read()
-    const lastOpened = settings.query || {}
-
-    // Ew means the workspace was closed so clear the last folder/workspace.
-    if (req.query.ew) {
-      delete lastOpened.folder
-      delete lastOpened.workspace
-    }
-
     if (!req.query.folder && !req.query.workspace) {
+      const settings = await req.settings.read()
+      const lastOpened = settings.query || {}
       let folder = undefined
       let workspace = undefined
       const to = self(req)
+
+      // Ew means the workspace was closed so clear the last folder/workspace.
+      if (req.query.ew) {
+        delete lastOpened.folder
+        delete lastOpened.workspace
+      }
+
       // Redirect to the last folder/workspace if nothing else is opened.
       if (
         (lastOpened.folder || lastOpened.workspace) &&

--- a/src/node/routes/vscode.ts
+++ b/src/node/routes/vscode.ts
@@ -34,9 +34,6 @@ export class CodeServerRouteWrapper {
       })
     }
 
-    let folder = undefined
-    let workspace = undefined
-    const to = self(req)
     const settings = await req.settings.read()
     const lastOpened = settings.query || {}
 
@@ -47,6 +44,9 @@ export class CodeServerRouteWrapper {
     }
 
     if (!req.query.folder && !req.query.workspace) {
+      let folder = undefined
+      let workspace = undefined
+      const to = self(req)
       // Redirect to the last folder/workspace if nothing else is opened.
       if (
         (lastOpened.folder || lastOpened.workspace) &&

--- a/test/unit/node/cli.test.ts
+++ b/test/unit/node/cli.test.ts
@@ -726,29 +726,6 @@ describe("toVsCodeArgs", () => {
   it("should convert empty args", async () => {
     expect(await toVsCodeArgs(await setDefaults(parse([])))).toStrictEqual({
       ...vscodeDefaults,
-      folder: "",
-      workspace: "",
-    })
-  })
-
-  it("should convert with workspace", async () => {
-    const workspace = path.join(await tmpdir(testName), "test.code-workspace")
-    await fs.writeFile(workspace, "foobar")
-    expect(await toVsCodeArgs(await setDefaults(parse([workspace])))).toStrictEqual({
-      ...vscodeDefaults,
-      workspace,
-      folder: "",
-      _: [workspace],
-    })
-  })
-
-  it("should convert with folder", async () => {
-    const folder = await tmpdir(testName)
-    expect(await toVsCodeArgs(await setDefaults(parse([folder])))).toStrictEqual({
-      ...vscodeDefaults,
-      folder,
-      workspace: "",
-      _: [folder],
     })
   })
 
@@ -757,8 +734,6 @@ describe("toVsCodeArgs", () => {
     await fs.writeFile(file, "foobar")
     expect(await toVsCodeArgs(await setDefaults(parse([file])))).toStrictEqual({
       ...vscodeDefaults,
-      folder: "",
-      workspace: "",
       _: [file],
     })
   })

--- a/test/unit/node/routes/vscode.test.ts
+++ b/test/unit/node/routes/vscode.test.ts
@@ -68,6 +68,7 @@ describe("vscode", () => {
 
     const folder = await tmpdir(testName)
     const workspace = path.join(await tmpdir(testName), "test.code-workspace")
+    await fs.writeFile(workspace, "")
     let resp = await codeServer.fetch("/", undefined, {
       folder,
       workspace,
@@ -115,6 +116,8 @@ describe("vscode", () => {
 
     const folder = await tmpdir(testName)
     const workspace = path.join(await tmpdir(testName), "test.code-workspace")
+    await fs.writeFile(workspace, "")
+
     let resp = await codeServer.fetch("/", undefined, {
       folder,
       workspace,

--- a/test/unit/node/routes/vscode.test.ts
+++ b/test/unit/node/routes/vscode.test.ts
@@ -29,7 +29,7 @@ describe("vscode", () => {
       expect(resp.status).toBe(200)
       const html = await resp.text()
       const url = new URL(resp.url) // Check there were no redirections.
-      expect(url.pathname + decodeURIComponent(url.search)).toBe(route)
+      expect(url.pathname + url.search).toBe(route)
       switch (route) {
         case "/":
         case "/vscode/":
@@ -42,7 +42,7 @@ describe("vscode", () => {
     }
   })
 
-  it("should redirect to the passed in workspace", async () => {
+  it("should redirect to the passed in workspace using human-readable query", async () => {
     const workspace = path.join(await tmpdir(testName), "test.code-workspace")
     await fs.writeFile(workspace, "")
     codeServer = await integration.setup(["--auth=none", workspace], "")
@@ -53,7 +53,7 @@ describe("vscode", () => {
     expect(url.search).toBe(`?workspace=${workspace}`)
   })
 
-  it("should redirect to the passed in directory", async () => {
+  it("should redirect to the passed in folder using human-readable query", async () => {
     const folder = await tmpdir(testName)
     codeServer = await integration.setup(["--auth=none", folder], "")
 
@@ -81,7 +81,7 @@ describe("vscode", () => {
       resp = await codeServer.fetch(route)
       const url = new URL(resp.url)
       expect(url.pathname).toBe(route)
-      expect(decodeURIComponent(url.search)).toBe(`?folder=${folder}&workspace=${workspace}`)
+      expect(url.search).toBe(`?folder=${folder}&workspace=${workspace}`)
       await resp.text()
     }
 
@@ -89,26 +89,13 @@ describe("vscode", () => {
     resp = await codeServer.fetch("/", undefined, { ew: "true" })
     let url = new URL(resp.url)
     expect(url.pathname).toBe("/")
-    expect(decodeURIComponent(url.search)).toBe("?ew=true")
+    expect(url.search).toBe("?ew=true")
     await resp.text()
 
     resp = await codeServer.fetch("/")
     url = new URL(resp.url)
     expect(url.pathname).toBe("/")
-    expect(decodeURIComponent(url.search)).toBe("")
-    await resp.text()
-  })
-
-  it("should add the workspace as a query param maintaining the slashes", async () => {
-    const workspace = path.join(await tmpdir(testName), "test.code-workspace")
-    await fs.writeFile(workspace, "")
-    codeServer = await integration.setup(["--auth=none", workspace], "")
-
-    let resp = await codeServer.fetch("/", undefined)
-
-    expect(resp.status).toBe(200)
-    const url = new URL(resp.url)
-    expect(url.search).toBe(`?workspace=${workspace}`)
+    expect(url.search).toBe("")
     await resp.text()
   })
 
@@ -120,18 +107,6 @@ describe("vscode", () => {
     expect(resp.status).toBe(200)
     const url = new URL(resp.url)
     expect(url.search).toBe("")
-    await resp.text()
-  })
-
-  it("should add the folder as a query param maintaining the slashes", async () => {
-    const folder = await tmpdir(testName)
-    codeServer = await integration.setup(["--auth=none", folder], "")
-
-    let resp = await codeServer.fetch("/", undefined)
-
-    expect(resp.status).toBe(200)
-    const url = new URL(resp.url)
-    expect(url.search).toBe(`?folder=${folder}`)
     await resp.text()
   })
 
@@ -151,7 +126,7 @@ describe("vscode", () => {
     resp = await codeServer.fetch("/")
     const url = new URL(resp.url)
     expect(url.pathname).toBe("/")
-    expect(decodeURIComponent(url.search)).toBe("")
+    expect(url.search).toBe("")
     await resp.text()
   })
 })

--- a/vendor/package.json
+++ b/vendor/package.json
@@ -7,6 +7,6 @@
     "postinstall": "./postinstall.sh"
   },
   "devDependencies": {
-    "code-oss-dev": "coder/vscode#0fd21e4078ac1dddb26be024f5d4224a4b86da93"
+    "code-oss-dev": "coder/vscode#bd734e3d9f21b1bce4dabab2514177e90c090ee6"
   }
 }

--- a/vendor/yarn.lock
+++ b/vendor/yarn.lock
@@ -274,9 +274,9 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-code-oss-dev@coder/vscode#0fd21e4078ac1dddb26be024f5d4224a4b86da93:
+code-oss-dev@coder/vscode#bd734e3d9f21b1bce4dabab2514177e90c090ee6:
   version "1.63.0"
-  resolved "https://codeload.github.com/coder/vscode/tar.gz/0fd21e4078ac1dddb26be024f5d4224a4b86da93"
+  resolved "https://codeload.github.com/coder/vscode/tar.gz/bd734e3d9f21b1bce4dabab2514177e90c090ee6"
   dependencies:
     "@microsoft/applicationinsights-web" "^2.6.4"
     "@parcel/watcher" "2.0.3"


### PR DESCRIPTION
Since we handle this in the vscode.ts route, we no longer need to pass it to VS
Code as a CLI arg since it's deprecated on that side.

This adds logic to our `vscode` route handler to handle both folder and workspace paths passed in via the CLI

Fixes an issue related to https://github.com/coder/vscode/pull/45

Blocked by https://github.com/coder/vscode/pull/49