### PR TITLE
fix: re-enable trivvy docker scan

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -464,7 +464,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Run Trivy vulnerability scanner in repo mode
-        #Commit SHA for v0.0.17
         uses: aquasecurity/trivy-action@296212627a1e693efa09c00adc3e03b2ba8edf18
         with:
           scan-type: "fs"

--- a/.github/workflows/trivy-docker.yaml
+++ b/.github/workflows/trivy-docker.yaml
@@ -45,7 +45,6 @@ concurrency:
 jobs:
   trivy-scan-image:
     runs-on: ubuntu-20.04
-    needs: docker-amd64
 
     steps:
       - name: Run Trivy vulnerability scanner in image mode

--- a/.github/workflows/trivy-docker.yaml
+++ b/.github/workflows/trivy-docker.yaml
@@ -1,0 +1,42 @@
+name: Trivy Nightly Docker Scan
+
+on:
+# TODO@jsjoeio do some nightly check
+
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+# Cancel in-progress runs for pull requests when developers push
+# additional changes, and serialize builds in branches.
+# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-concurrency-to-cancel-any-in-progress-job-or-run
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  trivy-scan-image:
+    runs-on: ubuntu-20.04
+    needs: docker-amd64
+
+    steps:
+      - name: Run Trivy vulnerability scanner in image mode
+        uses: aquasecurity/trivy-action@296212627a1e693efa09c00adc3e03b2ba8edf18
+        with:
+          image-ref: 'docker.io/codercom/code-server:latest
+          ignore-unfixed: true
+          format: 'sarif'
+          output: "trivy-image-results.sarif"
+          severity: "HIGH,CRITICAL"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: "trivy-image-results.sarif"

--- a/.github/workflows/trivy-docker.yaml
+++ b/.github/workflows/trivy-docker.yaml
@@ -1,7 +1,28 @@
 name: Trivy Nightly Docker Scan
 
 on:
-# TODO@jsjoeio do some nightly check
+  # Run scans if the workflow is modified, in order to test the
+  # workflow itself. This results in some spurious notifications,
+  # but seems okay for testing.
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/trivy-docker.yaml
+
+  # Run scans against master whenever changes are merged.
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/trivy-docker.yaml
+
+  schedule:
+    # Run at 10:15 am UTC (3:15am PT/5:15am CT)
+    # Run at 0 minutes 0 hours of every day.
+    - cron: "15 10 * * *"
+
+  workflow_dispatch:
 
 permissions:
   actions: none
@@ -30,9 +51,9 @@ jobs:
       - name: Run Trivy vulnerability scanner in image mode
         uses: aquasecurity/trivy-action@296212627a1e693efa09c00adc3e03b2ba8edf18
         with:
-          image-ref: 'docker.io/codercom/code-server:latest
+          image-ref: "docker.io/codercom/code-server:latest"
           ignore-unfixed: true
-          format: 'sarif'
+          format: "sarif"
           output: "trivy-image-results.sarif"
           severity: "HIGH,CRITICAL"
 

--- a/.github/workflows/trivy-docker.yaml
+++ b/.github/workflows/trivy-docker.yaml
@@ -47,6 +47,9 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Run Trivy vulnerability scanner in image mode
         uses: aquasecurity/trivy-action@296212627a1e693efa09c00adc3e03b2ba8edf18
         with:


### PR DESCRIPTION
This PR re-enables the trivy Docker scan as part of our CI pipeline. With this, we will have trivy do a security check on our Docker image tagged `latest` so that we can catch any security vulnerabilities.

## Testing

Example scan: https://github.com/coder/code-server/runs/5428919398?check_suite_focus=true

## Previous Context

@code-asher I were chatting about this. We want the scan to run on `latest` instead of the local build since the local build will use the newest dependencies. Instead, we want to check what's in production and ensure that it has no issues. We'll run this new workflow nightly (once a day) and check for any issues. This way, we can stay on top of the Docker image and fix things sooner.

Fixes #4903
