### PR TITLE
testing: add new test for logLevels

### DIFF
--- a/test/unit/node/cli.test.ts
+++ b/test/unit/node/cli.test.ts
@@ -192,8 +192,15 @@ describe("parser", () => {
     })
     expect(process.env.LOG_LEVEL).toEqual("trace")
     expect(logger.level).toEqual(Level.Trace)
+  })
 
-    // TODO@jsjoeio - add the test here for error
+  it("should set valid log level env var", async () => {
+    process.env.LOG_LEVEL = "error"
+    const defaults = await setDefaults(parse([]))
+    expect(defaults).toEqual({
+      ...defaults,
+      log: "error",
+    })
   })
 
   it("should ignore invalid log level env var", async () => {

--- a/test/unit/node/cli.test.ts
+++ b/test/unit/node/cli.test.ts
@@ -192,6 +192,8 @@ describe("parser", () => {
     })
     expect(process.env.LOG_LEVEL).toEqual("trace")
     expect(logger.level).toEqual(Level.Trace)
+
+    // TODO@jsjoeio - add the test here for error
   })
 
   it("should ignore invalid log level env var", async () => {


### PR DESCRIPTION
This adds a test to ensure that setting the log level with `process.env.LOG_LEVEL` to `error` sets it as expected. 

Fixes #4916
