### PR TITLE
chore: add permissions trivy-docker

### DIFF
--- a/.github/workflows/trivy-docker.yaml
+++ b/.github/workflows/trivy-docker.yaml
@@ -25,7 +25,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: none
+  actions: write
   checks: none
   contents: read
   deployments: none
@@ -33,7 +33,7 @@ permissions:
   packages: none
   pull-requests: none
   repository-projects: none
-  security-events: none
+  security-events: write
   statuses: none
 
 # Cancel in-progress runs for pull requests when developers push

--- a/.github/workflows/trivy-docker.yaml
+++ b/.github/workflows/trivy-docker.yaml
@@ -25,7 +25,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: write
+  actions: none
   checks: none
   contents: read
   deployments: none


### PR DESCRIPTION
Looks like I didn't give this workflow the right permissions: https://github.com/coder/code-server/runs/5432361797?check_suite_focus=true

I am not sure if `actions` needs `write` permissions or if `security` needs `write` permissions so I added it to both.

Fixes N/A
