### PR TITLE
feat(testing): add test for app > listen

### DIFF
--- a/src/node/app.ts
+++ b/src/node/app.ts
@@ -22,7 +22,7 @@ export interface App extends Disposable {
   server: http.Server
 }
 
-const listen = (server: http.Server, { host, port, socket, "socket-mode": mode }: ListenOptions) => {
+export const listen = (server: http.Server, { host, port, socket, "socket-mode": mode }: ListenOptions) => {
   return new Promise<void>(async (resolve, reject) => {
     server.on("error", reject)
 


### PR DESCRIPTION
This PR adds a new test to handle test when `fs.unlink` throws inside `listen`.

Fixes #4913 
