### PR TITLE
fix(ci): correctly download npm/docker artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -197,9 +197,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v3
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
         id: download
         with:
+          branch: release
+          workflow_conclusion: completed
           name: "npm-package"
           path: release-npm-package
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,7 +198,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download artifact
-      - uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3
         id: download
         with:
           name: "npm-package"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,11 +198,9 @@ jobs:
           fetch-depth: 0
 
       - name: Download artifact
-        uses: dawidd6/action-download-artifact@v2
+      - uses: actions/download-artifact@v3
         id: download
         with:
-          branch: release
-          workflow_conclusion: completed
           name: "npm-package"
           path: release-npm-package
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -35,15 +35,15 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Get version branch
-        id: version-branch
-        run: echo "::set-output name=name::v$(jq .version package.json)"
+      - name: Get version
+        id: version
+        run: echo "::set-output name=version::$(jq .version package.json)"
 
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2
         id: download
         with:
-          branch: v${{ steps.version-branch.outputs.name }}
+          branch: v${{ steps.version.outputs.version }}
           workflow_conclusion: completed
           name: "release-packages"
           path: release-packages

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -35,6 +35,19 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Get version branch
+        id: version-branch
+        run: echo "::set-output name=name::v$(jq .version package.json)"
+
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
+        id: download
+        with:
+          branch: v${{ steps.version-branch.outputs.name }}
+          workflow_conclusion: completed
+          name: "release-packages"
+          path: release-packages
+
       - name: Run ./ci/steps/docker-buildx-push.sh
         run: ./ci/steps/docker-buildx-push.sh
         env:

--- a/.github/workflows/npm-brew.yaml
+++ b/.github/workflows/npm-brew.yaml
@@ -23,15 +23,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Get version branch
-        id: version-branch
-        run: echo "::set-output name=name::v$(jq .version package.json)"
+      - name: Get version
+        id: version
+        run: echo "::set-output name=version::$(jq .version package.json)"
 
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2
         id: download
         with:
-          branch: v${{ steps.version-branch.outputs.name }}
+          branch: v${{ steps.version.outputs.version }}
           workflow_conclusion: completed
           name: "npm-package"
           path: release-npm-package

--- a/.github/workflows/npm-brew.yaml
+++ b/.github/workflows/npm-brew.yaml
@@ -23,12 +23,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v3
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
         id: download
         with:
+          branch: release
+          workflow_conclusion: completed
           name: "npm-package"
           path: release-npm-package
-
+      
       - name: Publish npm package and tag with "latest"
         run: yarn publish:npm
         env:

--- a/.github/workflows/npm-brew.yaml
+++ b/.github/workflows/npm-brew.yaml
@@ -31,7 +31,7 @@ jobs:
           workflow_conclusion: completed
           name: "npm-package"
           path: release-npm-package
-      
+
       - name: Publish npm package and tag with "latest"
         run: yarn publish:npm
         env:

--- a/.github/workflows/npm-brew.yaml
+++ b/.github/workflows/npm-brew.yaml
@@ -23,11 +23,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Get version branch
+        id: version-branch
+        run: echo "::set-output name=name::v$(jq .version package.json)"
+
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2
         id: download
         with:
-          branch: release
+          branch: v${{ steps.version-branch.outputs.name }}
           workflow_conclusion: completed
           name: "npm-package"
           path: release-npm-package

--- a/ci/build/release-github-assets.sh
+++ b/ci/build/release-github-assets.sh
@@ -9,6 +9,15 @@ set -euo pipefail
 main() {
   cd "$(dirname "$0")/../.."
   source ./ci/lib.sh
+  source ./ci/steps/steps-lib.sh
+
+  # NOTE@jsjoeio - only needed if we use the download_artifact
+  # because we talk to the GitHub API.
+  # Needed to use GitHub API
+  if ! is_env_var_set "GITHUB_TOKEN"; then
+    echo "GITHUB_TOKEN is not set. Cannot download npm release-packages without GitHub credentials."
+    exit 1
+  fi
 
   download_artifact release-packages ./release-packages
   local assets=(./release-packages/code-server*"$VERSION"*{.tar.gz,.deb,.rpm})

--- a/ci/steps/docker-buildx-push.sh
+++ b/ci/steps/docker-buildx-push.sh
@@ -4,12 +4,9 @@ set -euo pipefail
 main() {
   cd "$(dirname "$0")/../.."
 
-  # ci/lib.sh sets VERSION and provides download_artifact here
-  source ./ci/lib.sh
-
-  # Download the release-packages artifact
-  download_artifact release-packages ./release-packages
-
+  # NOTE@jsjoeio - this script assumes that you've downloaded
+  # the release-packages artifact to ./release-packages before
+  # running this docker buildx step
   docker buildx bake -f ci/release-image/docker-bake.hcl --push
 }
 

--- a/ci/steps/publish-npm.sh
+++ b/ci/steps/publish-npm.sh
@@ -13,14 +13,6 @@ main() {
     exit 1
   fi
 
-  # NOTE@jsjoeio - only needed if we use the download_artifact
-  # because we talk to the GitHub API.
-  # Needed to use GitHub API
-  if ! is_env_var_set "GITHUB_TOKEN"; then
-    echo "GITHUB_TOKEN is not set. Cannot download npm release artifact without GitHub credentials."
-    exit 1
-  fi
-
   ## Publishing Information
   # All the variables below are used to determine how we should publish
   # the npm package. We also use this information for bumping the version.

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -164,7 +164,7 @@ If you're the current release manager, follow these steps:
 
 ### Publishing a release
 
-1. Create a release branch called `v0.0.0` but replace with new version
+1. Create a new branch called `release` (the npm workflow will look for this when a new GitHub release is published)
 1. Run `yarn release:prep` and type in the new version (e.g., `3.8.1`)
 1. GitHub Actions will generate the `npm-package`, `release-packages` and
    `release-images` artifacts. You do not have to wait for this step to complete

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -164,7 +164,7 @@ If you're the current release manager, follow these steps:
 
 ### Publishing a release
 
-1. Create a new branch called `release` (the npm workflow will look for this when a new GitHub release is published)
+1. Create a new branch called `v0.0.0` (replace 0s with actual version aka v4.1.0)
 1. Run `yarn release:prep` and type in the new version (e.g., `3.8.1`)
 1. GitHub Actions will generate the `npm-package`, `release-packages` and
    `release-images` artifacts. You do not have to wait for this step to complete


### PR DESCRIPTION
## Context

This PR fixes the npm and docker workflows that runs on a release to correctly download artifacts so it can publish it to the npm and Docker registries. 

https://github.com/coder/code-server/blob/main/.github/workflows/npm-brew.yaml#L21-L37

### Problem

The default [`download-artifact`](https://github.com/actions/download-artifact) assumes that you're downloading artifacts from the running workflow. The problem is [`npm-brew.yaml`](https://github.com/coder/code-server/blob/main/.github/workflows/npm-brew.yaml#L21-L37) runs on [`released` events](https://github.com/coder/code-server/blob/main/.github/workflows/npm-brew.yaml#L8-L9).

Example: maintainer creates release branch `v4.1.0` ➡️ opens PR ➡️ team approves PR ➡️ maintainer merges PR into `main` ➡️ `npm` job from `npm-brew.yaml` and the `docker.yaml` workflows kick off. 

Therefore this workflow is not associated with any PR or any commit, but rather a GitHub event. 

### Solution

Download `npm-release` artifact and `release-packages` from last successful run where branch is named `v0.0.0` (with actual version) using this community GitHub Action [`dawidd6/action-download-artifact`](https://github.com/dawidd6/action-download-artifact).

#### Other considerations

_Why not use latest successful CI run for `main`?_

There would be a race condition since by the time the release PR gets merged and `main` finishes running, this npm workflow would already have run, so the last successful CI run for `main` wouldn't be 1:1 with the release branch merge commit.

_Why not use the same branch name each time like `release`?_

@vapurrmaid and @code-asher brought up a good point. If we do this, then we have no way to differentiate between a 4.1.0 and a 4.2.0 release workflow since they both use the same branch name. This is important because there are times we need to republish releases like on Docker and we'd want to use the same build. 

## Testing Plan

1. Fork `cdr/code-server`
2. Checkout this branch: https://github.com/jsjoeio/code-server/pull/2
3. Merge into `main` 
4. Create new branch called `release`
5. Get CI to run and pass.
6. Merge branch
7. Create new GitHub release
8. See if `npm-brew` runs and download-artifact works as expected: https://github.com/jsjoeio/code-server/runs/5562662740?check_suite_focus=true#step:3:16 

Fixes #4949
