### PR TITLE
refactor: checkout homebrew-core in action instead of script

### DIFF
--- a/.github/workflows/npm-brew.yaml
+++ b/.github/workflows/npm-brew.yaml
@@ -49,11 +49,19 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
-      - uses: actions/checkout@v3
+      - name: Checkout code-server
+        uses: actions/checkout@v3
+
+      - name: Checkout coder/homebrew-core
+        uses: actions/checkout@v3
+        with:
+          repository: coder/homebrew-core
+
       - name: Configure git
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
+
       - name: Bump code-server homebrew version
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}

--- a/.github/workflows/npm-brew.yaml
+++ b/.github/workflows/npm-brew.yaml
@@ -52,10 +52,10 @@ jobs:
       - name: Checkout code-server
         uses: actions/checkout@v3
 
-      - name: Checkout coder/homebrew-core
+      - name: Checkout cdrci/homebrew-core
         uses: actions/checkout@v3
         with:
-          repository: coder/homebrew-core
+          repository: cdrci/homebrew-core
 
       - name: Configure git
         run: |

--- a/.github/workflows/npm-brew.yaml
+++ b/.github/workflows/npm-brew.yaml
@@ -63,6 +63,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: cdrci/homebrew-core
+          path: homebrew-core
 
       - name: Configure git
         run: |

--- a/ci/steps/brew-bump.sh
+++ b/ci/steps/brew-bump.sh
@@ -6,8 +6,8 @@ main() {
   GITHUB_USERNAME="cdrci"
   UPSTREAM_USERNAME_AND_REPO="Homebrew/$REPO"
   # Only sourcing this so we get access to $VERSION
-  source ./lib.sh
-  source ./steps-lib.sh
+  source ./ci/lib.sh
+  source ./ci/steps-lib.sh
 
   echo "Checking environment variables"
 

--- a/ci/steps/brew-bump.sh
+++ b/ci/steps/brew-bump.sh
@@ -7,7 +7,7 @@ main() {
   UPSTREAM_USERNAME_AND_REPO="Homebrew/$REPO"
   # Only sourcing this so we get access to $VERSION
   source ./ci/lib.sh
-  source ./ci/steps-lib.sh
+  source ./ci/steps/steps-lib.sh
 
   echo "Checking environment variables"
 

--- a/ci/steps/brew-bump.sh
+++ b/ci/steps/brew-bump.sh
@@ -89,16 +89,6 @@ main() {
   # https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/bump-formula-pr.rb#L18
   # local output
   brew bump-formula-pr --version="${VERSION}" code-server --no-browse --no-audit
-
-  # Clean up and remove homebrew-core
-  popd
-  rm -rf "$REPO"
-
-  # Make sure $REPO is removed
-  if directory_exists "$REPO"; then
-    echo "rm -rf $REPO failed."
-    ls -la
-  fi
 }
 
 main "$@"

--- a/ci/steps/brew-bump.sh
+++ b/ci/steps/brew-bump.sh
@@ -87,8 +87,16 @@ main() {
 
   # Find the docs for bump-formula-pr here
   # https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/bump-formula-pr.rb#L18
-  # local output
-  brew bump-formula-pr --version="${VERSION}" code-server --no-browse --no-audit
+  local output
+  if ! output=$(brew bump-formula-pr --version="${VERSION}" code-server --no-browse --no-audit 2>&1); then
+    if [[ $output == *"Duplicate PRs should not be opened"* ]]; then
+      echo "$VERSION is already submitted"
+      exit 0
+    else
+      echo "$output"
+      exit 1
+    fi
+  fi
 }
 
 main "$@"

--- a/ci/steps/brew-bump.sh
+++ b/ci/steps/brew-bump.sh
@@ -21,15 +21,8 @@ main() {
     exit 1
   fi
 
-  # NOTE: we need to make sure coderci/homebrew-core
-  # is up-to-date
-  # otherwise, brew bump-formula-pr will use an
-  # outdated base
-  echo "Cloning coderci/homebrew-core"
-  git clone https://github.com/coderci/homebrew-core.git
-
   # Make sure the git clone step is successful
-  if directory_exists "homebrew-core"; then
+  if ! directory_exists "homebrew-core"; then
     echo "git clone failed. Cannot find homebrew-core directory."
     ls -la
     exit 1
@@ -67,7 +60,7 @@ main() {
   echo 'echo $HOMEBREW_GITHUB_API_TOKEN' > "$PATH_TO_ASKPASS"
 
   # Make sure the git-askpass.sh file creation is successful
-  if file_exists "$PATH_TO_GIT_ASKPASS"; then
+  if ! file_exists "$PATH_TO_GIT_ASKPASS"; then
     echo "git-askpass.sh not found in $HOME."
     ls -la "$HOME"
     exit 1
@@ -77,7 +70,7 @@ main() {
   chmod +x "$PATH_TO_GIT_ASKPASS"
 
   # Make sure the git-askpass.sh file is executable
-  if is_executable "$PATH_TO_GIT_ASKPASS"; then
+  if ! is_executable "$PATH_TO_GIT_ASKPASS"; then
     echo "$PATH_TO_GIT_ASKPASS is not executable."
     ls -la "$PATH_TO_GIT_ASKPASS"
     exit 1


### PR DESCRIPTION
This fixes the `brew-bump.sh` script by using the correct logic. It also moves a `git clone` line from the script to a step in the `homebrew` job.

## Testing Plan

1. Fork `coder/code-server`
2. hard-code `VERSION` to `4.1.0-4970-6afc87b46dfa70adc0afe164a89662aac1a0b0cd` (otherwise it will fail) and disable `npm` job
3. Push up this change to a new branch
4. Add `HOMEBREW_GITHUB_API_TOKEN` as secret to fork (using my own token).
5. Manually dispatch action
6. See that it opens a PR upstream in homebrew-core

✅ tested this with @cdr-oss account on Coder workspace
✅ tested with @cdrci account and it worked: https://github.com/Homebrew/homebrew-core/pull/97235 (oops, should have just used the `--dry-run` option)


## Other Notes
🔑 Updated the `HOMEBREW_GITHUB_API_TOKEN` under secrets with a PAT generated by @deansheather from the @cdrci account which has the scopes `repo` and `workflow`.

Fixes #4950
