### PR TITLE
feat: Add a shrinkwrap file to the NPM release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -57,7 +57,7 @@ body:
     id: logs
     attributes:
       label: Logs
-      description: Run code-server with the --verbose flag and then paste any relevant logs from the server, from the browser console and/or the browser network tab. For issues with installation, include installation logs (i.e. output of `yarn global add code-server`).
+      description: Run code-server with the --verbose flag and then paste any relevant logs from the server, from the browser console and/or the browser network tab. For issues with installation, include installation logs (i.e. output of `npm install -g code-server`).
   - type: textarea
     attributes:
       label: Screenshot/Video

--- a/ci/steps/publish-npm.sh
+++ b/ci/steps/publish-npm.sh
@@ -59,11 +59,11 @@ main() {
   # This string is used to determine how we should tag the npm release.
   # Environment can be one of three choices:
   # "development" - this means we tag with the PR number, allowing
-  # a developer to install this version with `yarn add code-server@<pr-number>`
+  # a developer to install this version with `npm install code-server@<pr-number>`
   # "staging" - this means we tag with `beta`, allowing
-  # a developer to install this version with `yarn add code-server@beta`
+  # a developer to install this version with `npm install code-server@beta`
   # "production" - this means we tag with `latest` (default), allowing
-  # a developer to install this version with `yarn add code-server@latest`
+  # a developer to install this version with `npm install code-server@latest`
   if ! is_env_var_set "NPM_ENVIRONMENT"; then
     echo "NPM_ENVIRONMENT is not set. Determining in script based on GITHUB environment variables."
 
@@ -96,7 +96,7 @@ main() {
   if [[ "$NPM_ENVIRONMENT" == "production" ]]; then
     NPM_VERSION="$VERSION"
     # This means the npm version will be published as "stable"
-    # and installed when a user runs `yarn install code-server`
+    # and installed when a user runs `npm install code-server`
     NPM_TAG="latest"
   else
     COMMIT_SHA="$GITHUB_SHA"
@@ -107,7 +107,7 @@ main() {
     if [[ "$NPM_ENVIRONMENT" == "staging" ]]; then
       NPM_VERSION="$VERSION-beta-$COMMIT_SHA"
       # This means the npm version will be tagged with "beta"
-      # and installed when a user runs `yarn install code-server@beta`
+      # and installed when a user runs `npm install code-server@beta`
       NPM_TAG="beta"
     fi
 
@@ -117,7 +117,7 @@ main() {
       NPM_VERSION="$VERSION-$PR_NUMBER-$COMMIT_SHA"
       PACKAGE_NAME="@coder/code-server-pr"
       # This means the npm version will be tagged with "<pr number>"
-      # and installed when a user runs `yarn install code-server@<pr number>`
+      # and installed when a user runs `npm install code-server@<pr number>`
       NPM_TAG="$PR_NUMBER"
     fi
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -3,7 +3,7 @@
 1. Install UserLAnd from [Google Play](https://play.google.com/store/apps/details?id=tech.ula&hl=en_US&gl=US)
 2. Install an Ubuntu VM
 3. Start app
-4. Install Node.js, `curl` and `yarn` using `sudo apt install nodejs npm yarn curl -y`
+4. Install Node.js, `curl` and `npm` using `sudo apt install nodejs npm curl -y`
 5. Install `nvm`:
 
 ```shell

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,7 +4,7 @@
 
 - [install.sh](#installsh)
   - [Detection reference](#detection-reference)
-- [yarn, npm](#yarn-npm)
+- [npm](#npm)
 - [Standalone releases](#standalone-releases)
 - [Debian, Ubuntu](#debian-ubuntu)
 - [Fedora, CentOS, RHEL, SUSE](#fedora-centos-rhel-suse)
@@ -19,7 +19,7 @@
 - [Uninstall](#uninstall)
   - [install.sh](#installsh-1)
   - [Homebrew](#homebrew)
-  - [yarn, npm](#yarn-npm-1)
+  - [npm](#npm-1)
   - [Debian, Ubuntu](#debian-ubuntu-1)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -87,17 +87,16 @@ _exact_ same commands presented in the rest of this document.
 
   - Ensure that you add `~/.local/bin` to your `$PATH` to run code-server.
 
-- For FreeBSD, code-server will install the [npm package](#yarn-npm) with `yarn`
-  or `npm`.
+- For FreeBSD, code-server will install the [npm package](#npm) with `npm`.
 
 - If you're installing code-server onto architecture with no releases,
-  code-server will install the [npm package](#yarn-npm) with `yarn` or `npm`
+  code-server will install the [npm package](#npm) with `npm`
   - We currently offer releases for amd64 and arm64.
-  - The [npm package](#yarn-npm) builds the native modules on post-install.
+  - The [npm package](#npm) builds the native modules on post-install.
 
-## yarn, npm
+## npm
 
-We recommend installing with `yarn` or `npm` when:
+We recommend installing with `npm` when:
 
 1. You aren't using a machine with `amd64` or `arm64`.
 1. You are installing code-server on Windows
@@ -107,9 +106,9 @@ We recommend installing with `yarn` or `npm` when:
    [#1430](https://github.com/coder/code-server/issues/1430#issuecomment-629883198)
    for more information.
 
-Installing code-server with `yarn` or `npm` builds native modules on install.
+Installing code-server with `npm` builds native modules on install.
 
-This process requires C dependencies; see our guide on [installing with yarn and npm][./npm.md](./npm.md) for more information.
+This process requires C dependencies; see our guide on [installing with `npm`][./npm.md](./npm.md) for more information.
 
 ## Standalone releases
 
@@ -117,7 +116,7 @@ We publish self-contained `.tar.gz` archives for every release on
 [GitHub](https://github.com/coder/code-server/releases). The archives bundle the
 node binary and node modules.
 
-We create the standalone releases using the [npm package](#yarn-npm), and we
+We create the standalone releases using the [npm package](#npm), and we
 then create the remaining releases using the standalone version.
 
 The only requirement to use the standalone release is `glibc` >= 2.17 and
@@ -151,7 +150,7 @@ code-server
 ## Debian, Ubuntu
 
 > The standalone arm64 .deb does not support Ubuntu 16.04 or earlier. Please
-> upgrade or [build with yarn](#yarn-npm).
+> upgrade or [build with `npm`](#npm).
 
 ```bash
 curl -fOL https://github.com/coder/code-server/releases/download/v$VERSION/code-server_$VERSION_amd64.deb
@@ -163,7 +162,7 @@ sudo systemctl enable --now code-server@$USER
 ## Fedora, CentOS, RHEL, SUSE
 
 > The standalone arm64 .rpm does not support CentOS 7. Please upgrade or [build
-> with yarn](#yarn-npm).
+> with `npm`](#npm).
 
 ```bash
 curl -fOL https://github.com/coder/code-server/releases/download/v$VERSION/code-server-$VERSION-amd64.rpm
@@ -228,14 +227,13 @@ You can install code-server using the [Helm package manager](https://coder.com/d
 
 ## Windows
 
-We currently [do not publish Windows releases](https://github.com/coder/code-server/issues/1397). We recommend installing code-server onto Windows with [`yarn` or `npm`](#yarn-npm).
+We currently [do not publish Windows releases](https://github.com/coder/code-server/issues/1397). We recommend installing code-server onto Windows with [ `npm`](#npm).
 
 > Note: You will also need to [build coder/cloud-agent manually](https://github.com/coder/cloud-agent/issues/17) if you would like to use `code-server --link` on Windows.
 
 ## Raspberry Pi
 
-We recommend installing code-server onto Raspberry Pi with [`yarn` or
-`npm`](#yarn-npm).
+We recommend installing code-server onto Raspberry Pi with [`npm`](#npm).
 
 ## Termux
 
@@ -277,15 +275,9 @@ brew remove code-server
 brew uninstall code-server
 ```
 
-### yarn, npm
+### npm
 
 To remove the code-server global module, run:
-
-```shell
-yarn global remove code-server
-```
-
-or
 
 ```shell
 npm uninstall -g code-server

--- a/docs/install.md
+++ b/docs/install.md
@@ -227,7 +227,7 @@ You can install code-server using the [Helm package manager](https://coder.com/d
 
 ## Windows
 
-We currently [do not publish Windows releases](https://github.com/coder/code-server/issues/1397). We recommend installing code-server onto Windows with [ `npm`](#npm).
+We currently [do not publish Windows releases](https://github.com/coder/code-server/issues/1397). We recommend installing code-server onto Windows with [`npm`](#npm).
 
 > Note: You will also need to [build coder/cloud-agent manually](https://github.com/coder/cloud-agent/issues/17) if you would like to use `code-server --link` on Windows.
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -21,7 +21,7 @@
       "children": [
         {
           "title": "npm",
-          "description": "How to install code-server using npm or yarn",
+          "description": "How to install code-server using npm",
           "path": "./npm.md"
         },
         {

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -20,6 +20,11 @@ If you're installing code-server via `npm`, you'll need to install additional
 dependencies required to build the native modules used by VS Code. This article
 includes installing instructions based on your operating system.
 
+> **WARNING**: Do not use `yarn` to install code-server. Unlike `npm`, it does not respect
+> lockfiles for distributed applications. It will instead use the latest version
+> available at installation time - which might not be the one used for a given
+> code-server release, and [might lead to unexpected behavior](https://github.com/coder/code-server/issues/4927).
+
 ## Node.js version
 
 We use the same major version of Node.js shipped with VSCode's Electron,
@@ -72,7 +77,7 @@ Proceed to [installing](#installing)
 ## FreeBSD
 
 ```sh
-pkg install -y git python npm-node14 yarn-node14 pkgconf
+pkg install -y git python npm-node14 pkgconf
 pkg install -y libinotify
 ```
 
@@ -85,8 +90,7 @@ Installing code-server requires all of the [prerequisites for VS Code developmen
 Next, install code-server with:
 
 ```bash
-yarn global add code-server
-# Or: npm install -g code-server
+npm install -g code-server
 code-server
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```
@@ -96,8 +100,7 @@ A `postinstall.sh` script will attempt to run. Select your terminal (e.g., Git b
 If the `code-server` command is not found, you'll need to [add a directory to your PATH](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/). To find the directory, use the following command:
 
 ```shell
-yarn global bin
-# Or: npm config get prefix
+npm config get prefix
 ```
 
 For help and additional troubleshooting, see [#1397](https://github.com/coder/code-server/issues/1397).
@@ -107,8 +110,7 @@ For help and additional troubleshooting, see [#1397](https://github.com/coder/co
 After adding the dependencies for your OS, install the code-server package globally:
 
 ```bash
-yarn global add code-server
-# Or: npm install -g code-server
+npm install -g code-server
 code-server
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```
@@ -122,7 +124,7 @@ page](https://github.com/coder/code-server/discussions).
 
 Occasionally, you may run into issues with Node.js.
 
-If you install code-server using `yarn` or `npm`, and you upgrade your Node.js
+If you install code-server using `npm`, and you upgrade your Node.js
 version, you may need to reinstall code-server to recompile native modules.
 Sometimes, you can get around this by navigating into code-server's `lib/vscode`
 directory and running `npm rebuild` to recompile the modules.
@@ -136,7 +138,7 @@ A step-by-step example of how you might do this is:
 
 ### Debugging install issues with npm
 
-`yarn` suppresses logs when running `yarn global add`, so to debug installation issues, install with `npm` instead:
+To debug installation issues:
 
 ```shell
 # Uninstall

--- a/install.sh
+++ b/install.sh
@@ -55,7 +55,7 @@ The detection method works as follows:
   - Debian, Ubuntu, Raspbian: install the deb package from GitHub.
   - Fedora, CentOS, RHEL, openSUSE: install the rpm package from GitHub.
   - Arch Linux: install from the AUR (which pulls releases from GitHub).
-  - FreeBSD, Alpine: install from yarn/npm.
+  - FreeBSD, Alpine: install from npm.
   - macOS: install using Homebrew if installed otherwise install from GitHub.
   - All others: install the release from GitHub.
 
@@ -419,19 +419,9 @@ install_npm() {
   echoh "Installing latest from npm."
   echoh
 
-  YARN_PATH="${YARN_PATH-yarn}"
   NPM_PATH="${YARN_PATH-npm}"
-  if command_exists "$YARN_PATH"; then
-    sh_c="sh_c"
-    if [ ! "${DRY_RUN-}" ] && [ ! -w "$($YARN_PATH global bin)" ]; then
-      sh_c="sudo_sh_c"
-    fi
-    echoh "Installing with yarn."
-    echoh
-    "$sh_c" "$YARN_PATH" global add code-server --unsafe-perm
-    NPM_BIN_DIR="\$($YARN_PATH global bin)" echo_npm_postinstall
-    return
-  elif command_exists "$NPM_PATH"; then
+
+  if command_exists "$NPM_PATH"; then
     sh_c="sh_c"
     if [ ! "${DRY_RUN-}" ] && [ ! -w "$(NPM_PATH config get prefix)" ]; then
       sh_c="sudo_sh_c"
@@ -442,9 +432,9 @@ install_npm() {
     NPM_BIN_DIR="\$($NPM_PATH bin -g)" echo_npm_postinstall
     return
   fi
-  echoerr "Please install npm or yarn to install code-server!"
+  echoerr "Please install npm to install code-server!"
   echoerr "You will need at least node v12 and a few C dependencies."
-  echoerr "See the docs https://coder.com/docs/code-server/latest/install#yarn-npm"
+  echoerr "See the docs https://coder.com/docs/code-server/latest/install#npm"
 
   exit 1
 }

--- a/package.json
+++ b/package.json
@@ -59,11 +59,13 @@
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-prettier": "^4.0.0",
+    "json": "^11.0.0",
     "prettier": "^2.2.1",
     "prettier-plugin-sh": "^0.8.0",
     "shellcheck": "^1.0.0",
     "stylelint": "^13.0.0",
     "stylelint-config-recommended": "^5.0.0",
+    "synp": "^1.9.10",
     "ts-node": "^10.0.0",
     "typescript": "^4.4.0-dev.20210528"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -577,6 +577,11 @@
     "@typescript-eslint/types" "5.2.0"
     eslint-visitor-keys "^3.0.0"
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 JSONStream@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -721,6 +726,11 @@ argv@0.0.2:
   resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
   integrity sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=
 
+arr-union@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
+  integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+
 array-flatten@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.1.tgz#426bb9da84090c1838d812c8150af20a8331e296"
@@ -809,6 +819,27 @@ balanced-match@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
   integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
+
+bash-glob@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bash-glob/-/bash-glob-2.0.0.tgz#a8ef19450783403ed93fccca2dbe09f2cf6320dc"
+  integrity sha512-53/NJ+t2UAkEYgQPO6aFjbx1Ue8vNNXCYaA4EljNKP1SR8A9dSQQoBmYWR8BLXO0/NDRJEMSJ4BxWihi//m3Kw==
+  dependencies:
+    bash-path "^1.0.1"
+    component-emitter "^1.2.1"
+    cross-spawn "^5.1.0"
+    each-parallel-async "^1.0.0"
+    extend-shallow "^2.0.1"
+    is-extglob "^2.1.1"
+    is-glob "^4.0.0"
+
+bash-path@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/bash-path/-/bash-path-1.0.3.tgz#dbc9efbdf18b1c11413dcb59b960e6aa56c84258"
+  integrity sha512-mGrYvOa6yTY/qNCiZkPFJqWmODK68y6kmVRAJ1NNbWlNoJrUrsFxu7FU2EKg7gbrer6ttrKkF2s/E/lhRy7/OA==
+  dependencies:
+    arr-union "^3.1.0"
+    is-windows "^1.0.1"
 
 body-parser@1.19.0:
   version "1.19.0"
@@ -1040,6 +1071,26 @@ colorette@^1.2.1, colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
+colors@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
+commander@^2.11.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+commander@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
+component-emitter@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
+  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+
 compressible@~2.0.16:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"
@@ -1127,6 +1178,15 @@ create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
+cross-spawn@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
@@ -1355,6 +1415,11 @@ duplexer@^0.1.1, duplexer@~0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
+each-parallel-async@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/each-parallel-async/-/each-parallel-async-1.0.0.tgz#91783e190000c7dd588336b2d468ebaf71980f7b"
+  integrity sha512-P/9kLQiQj0vZNzphvKKTgRgMnlqs5cJsxeAiuog1jrUnwv0Z3hVUwJDQiP7MnLb2I9S15nR9SRUceFT9IxtqRg==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -1401,6 +1466,11 @@ env-paths@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
+
+eol@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/eol/-/eol-0.9.1.tgz#f701912f504074be35c6117a5c4ade49cd547acd"
+  integrity sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -1729,6 +1799,13 @@ express@5.0.0-alpha.8:
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
+
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  integrity sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=
+  dependencies:
+    is-extendable "^0.1.0"
 
 extend@^3.0.0:
   version "3.0.2"
@@ -2357,6 +2434,11 @@ is-decimal@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
   integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
 
+is-extendable@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+  integrity sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -2451,6 +2533,11 @@ is-whitespace-character@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz#0858edd94a95594c7c9dd0b5c174ec6e45ee4aa7"
   integrity sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==
 
+is-windows@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+  integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
 is-word-character@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.4.tgz#ce0e73216f98599060592f62ff31354ddbeb0230"
@@ -2534,6 +2621,11 @@ json5@^2.1.2:
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   dependencies:
     minimist "^1.2.5"
+
+json@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/json/-/json-11.0.0.tgz#2e84493134e2f42c131165aa22a124df38b3a3ee"
+  integrity sha512-N/ITv3Yw9Za8cGxuQqSqrq6RHnlaHWZkAFavcfpH/R52522c26EbihMxnY7A1chxfXJ4d+cEFIsyTgfi9GihrA==
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -2623,7 +2715,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.17.19, lodash@^4.17.21:
+lodash@4.17.21, lodash@^4.17.19, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2640,6 +2732,14 @@ longest-streak@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
   integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
+
+lru-cache@^4.0.1:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -2895,6 +2995,13 @@ netmask@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7"
   integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
+
+nmtree@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/nmtree/-/nmtree-1.0.6.tgz#953e057ad545e9e627f1275bd25fea4e92c1cf63"
+  integrity sha512-SUPCoyX5w/lOT6wD/PZEymR+J899984tYEOYjuDqQlIOeX5NSb1MEsCcT0az+dhZD0MLAj5hGBZEpKQxuDdniA==
+  dependencies:
+    commander "^2.11.0"
 
 node-addon-api@^4.3.0:
   version "4.3.0"
@@ -3381,6 +3488,11 @@ proxy-from-env@^1.0.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
+
 punycode@^1.3.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -3726,12 +3838,24 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
+  dependencies:
+    shebang-regex "^1.0.0"
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
   integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   dependencies:
     shebang-regex "^3.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
 shebang-regex@^3.0.0:
   version "3.0.0"
@@ -3797,6 +3921,11 @@ socks@^2.3.3:
   dependencies:
     ip "^1.1.5"
     smart-buffer "^4.1.0"
+
+sort-object-keys@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/sort-object-keys/-/sort-object-keys-1.1.3.tgz#bff833fe85cab147b34742e45863453c1e190b45"
+  integrity sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==
 
 source-map-support@^0.5.17:
   version "0.5.19"
@@ -4067,6 +4196,21 @@ svg-tags@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
   integrity sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=
+
+synp@^1.9.10:
+  version "1.9.10"
+  resolved "https://registry.yarnpkg.com/synp/-/synp-1.9.10.tgz#53163321a600418c9b06af0db499939ffce12907"
+  integrity sha512-G9Z/TXTaBG1xNslUf3dHFidz/8tvvRaR560WWyOwyI7XrGGEGBTEIIg4hdRh1qFtz8mPYynAUYwWXUg/Zh0Pzw==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    bash-glob "^2.0.0"
+    colors "1.4.0"
+    commander "^7.2.0"
+    eol "^0.9.1"
+    lodash "4.17.21"
+    nmtree "^1.0.6"
+    semver "^7.3.5"
+    sort-object-keys "^1.1.3"
 
 table@^6.0.9, table@^6.6.0:
   version "6.7.1"
@@ -4486,7 +4630,7 @@ which-boxed-primitive@^1.0.2:
     is-string "^1.0.5"
     is-symbol "^1.0.3"
 
-which@^1.3.1:
+which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -4565,6 +4709,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^3.0.2:
   version "3.1.1"


### PR DESCRIPTION
Fixes #4927

Tried multiple ideas/approaches, this is the least worst I could find. Happy to amend/change things, and at least this will get the discussion going.

Here's a diff from an npm install before the change (left - installing from the public repos) and after (right - installing from the tar.gz generated by the build): https://editor.mergely.com/8tpzCXG6/

As expected, some versions have been bumped down, to actually follow what the yarn.lock had:
* `rotating-file-stream@3.0.3` => `rotating-file-stream@3.0.0` as per the [yarn.lock](https://github.com/coder/code-server/blob/be727871f6f7f0af48e9e3d0039d59aa46c855b5/yarn.lock#L3627)
* `argon2@0.28.5` => `argon2@0.28.4` as per the [yarn.lock](https://github.com/coder/code-server/blob/be727871f6f7f0af48e9e3d0039d59aa46c855b5/yarn.lock#L698)

For this approach, I'm introducing two new devDependencies:
* `synp`, which means we can seed the shrinkwrap from the yarn.lock - rather than maintaining two different ones.
* `json`, to do some simplifications on the shrinkwrap file. Effectively, this is similar to `jq` - but a bit simpler for this use-case. And also, opens the door to not have to require `jq` from being installed, as this is a pure NPM package that can be declared as a dependency. Might check later if I can easily migrate every `jq` command to it.

I tried using `npm shrinkwrap` directly, but the current NPM and NodeJS versions being used seem to choke when `resolutions` is used to force newer versions of transitive dependencies we don't depend on (they generate a package-lock.json without a version...). Not even sure why those resolutions are needed...?