### PR TITLE
fix: use -r with jq and add workflow for artifacts

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -37,13 +37,14 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "::set-output name=version::$(jq .version package.json)"
+        run: echo "::set-output name=version::$(jq -r .version package.json)"
 
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2
         id: download
         with:
           branch: v${{ steps.version.outputs.version }}
+          workflow: ci.yaml
           workflow_conclusion: completed
           name: "release-packages"
           path: release-packages

--- a/.github/workflows/npm-brew.yaml
+++ b/.github/workflows/npm-brew.yaml
@@ -25,13 +25,14 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "::set-output name=version::$(jq .version package.json)"
+        run: echo "::set-output name=version::$(jq -r .version package.json)"
 
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2
         id: download
         with:
           branch: v${{ steps.version.outputs.version }}
+          workflow: ci.yaml
           workflow_conclusion: completed
           name: "npm-package"
           path: release-npm-package


### PR DESCRIPTION
Uses raw output when using `jq` so branch name isn't in quotes and adds workflow for artifact download.

Fixes N/A
