### PR TITLE
fix: source lib.sh in docker-buildx-push for tagging version

### DIFF
--- a/ci/steps/docker-buildx-push.sh
+++ b/ci/steps/docker-buildx-push.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 main() {
   cd "$(dirname "$0")/../.."
+  # ci/lib.sh sets VERSION so it's available to ci/release-image/docker-bake.hcl
+  # to push the VERSION tag.
+  source ./ci/lib.sh
 
   # NOTE@jsjoeio - this script assumes that you've downloaded
   # the release-packages artifact to ./release-packages before


### PR DESCRIPTION
I didn't realize the Docker workflow needed `VERSION` to publish a tag. This fixes that workflow. 

See https://github.com/coder/code-server/issues/5022#issuecomment-1076869631 for more context

Todos
- [ ] manually dispatch Docker publish workflow to push `4.2.0` version

Fixes #5022
