### PR TITLE
refactor(brew-bump): fix homebrew bump script

### DIFF
--- a/.github/workflows/npm-brew.yaml
+++ b/.github/workflows/npm-brew.yaml
@@ -45,10 +45,8 @@ jobs:
           NPM_ENVIRONMENT: "production"
 
   homebrew:
-    # The newest version of code-server needs to be available on npm when this runs
-    # otherwise, it will 404 and won't open a PR to bump version on homebrew/homebrew-core
     needs: npm
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       # Ensure things are up to date
       # Suggested by homebrew maintainers
@@ -60,16 +58,10 @@ jobs:
       - name: Checkout code-server
         uses: actions/checkout@v3
 
-      - name: Checkout cdrci/homebrew-core
-        uses: actions/checkout@v3
-        with:
-          repository: cdrci/homebrew-core
-          path: homebrew-core
-
       - name: Configure git
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name cdrci
+          git config user.email opensource@coder.com
 
       - name: Bump code-server homebrew version
         env:

--- a/ci/steps/brew-bump.sh
+++ b/ci/steps/brew-bump.sh
@@ -2,9 +2,6 @@
 set -euo pipefail
 
 main() {
-  REPO="homebrew-core"
-  GITHUB_USERNAME="cdrci"
-  UPSTREAM_USERNAME_AND_REPO="Homebrew/$REPO"
   # Only sourcing this so we get access to $VERSION
   source ./ci/lib.sh
   source ./ci/steps/steps-lib.sh
@@ -22,68 +19,6 @@ main() {
     echo "HOMEBREW_GITHUB_API_TOKEN is not set"
     exit 1
   fi
-
-  # Make sure the git clone step is successful
-  if ! directory_exists "$REPO"; then
-    echo "git clone failed. Cannot find $REPO directory."
-    ls -la
-    exit 1
-  fi
-
-  echo "Changing into $REPO directory"
-  pushd "$REPO" && pwd
-
-  echo "Adding $UPSTREAM_USERNAME_AND_REPO"
-  git remote add upstream "https://github.com/$UPSTREAM_USERNAME_AND_REPO.git"
-
-  # Make sure the git remote step is successful
-  if ! git config remote.upstream.url > /dev/null; then
-    echo "git remote add upstream failed."
-    echo "Could not find upstream in list of remotes."
-    git remote -v
-    exit 1
-  fi
-
-  # TODO@jsjoeio - can I somehow check that this succeeded?
-  echo "Fetching upstream $UPSTREAM_USERNAME_AND_REPO commits"
-  git fetch upstream master
-
-  # TODO@jsjoeio - can I somehow check that this succeeded?
-  echo "Merging in latest $UPSTREAM_USERNAME_AND_REPO changes branch master"
-  git merge upstream/master
-
-  # GIT_ASKPASS lets us use the password when pushing without revealing it in the process list
-  # See: https://serverfault.com/a/912788
-  PATH_TO_GIT_ASKPASS="$HOME/git-askpass.sh"
-  # Source: https://serverfault.com/a/912788
-  # shellcheck disable=SC2016,SC2028
-  echo 'echo $HOMEBREW_GITHUB_API_TOKEN' > "$PATH_TO_GIT_ASKPASS"
-
-  # Make sure the git-askpass.sh file creation is successful
-  if ! file_exists "$PATH_TO_GIT_ASKPASS"; then
-    echo "git-askpass.sh not found in $HOME."
-    ls -la "$HOME"
-    exit 1
-  fi
-
-  # Ensure it's executable since we just created it
-  chmod +x "$PATH_TO_GIT_ASKPASS"
-
-  # Make sure the git-askpass.sh file is executable
-  if ! is_executable "$PATH_TO_GIT_ASKPASS"; then
-    echo "$PATH_TO_GIT_ASKPASS is not executable."
-    ls -la "$PATH_TO_GIT_ASKPASS"
-    exit 1
-  fi
-
-  # NOTE: we need to make sure our fork is up-to-date
-  # otherwise, brew bump-formula-pr will use an
-  # outdated base
-  echo "Pushing changes to $GITHUB_USERNAME/$REPO fork on GitHub"
-  # Export the variables so git sees them
-  export HOMEBREW_GITHUB_API_TOKEN="$HOMEBREW_GITHUB_API_TOKEN"
-  export GIT_ASKPASS="$PATH_TO_GIT_ASKPASS"
-  git push "https://$GITHUB_USERNAME@github.com/$GITHUB_USERNAME/$REPO.git" --all
 
   # Find the docs for bump-formula-pr here
   # https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/bump-formula-pr.rb#L18

--- a/ci/steps/docker-buildx-push.sh
+++ b/ci/steps/docker-buildx-push.sh
@@ -3,9 +3,6 @@ set -euo pipefail
 
 main() {
   cd "$(dirname "$0")/../.."
-  # ci/lib.sh sets VERSION so it's available to ci/release-image/docker-bake.hcl
-  # to push the VERSION tag.
-  source ./ci/lib.sh
 
   # NOTE@jsjoeio - this script assumes that you've downloaded
   # the release-packages artifact to ./release-packages before

--- a/ci/steps/docker-buildx-push.sh
+++ b/ci/steps/docker-buildx-push.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 main() {
   cd "$(dirname "$0")/../.."
+  # ci/lib.sh sets VERSION so it's available to ci/release-image/docker-bake.hcl
+  # to push the VERSION tag.
+  source ./ci/lib.sh
 
   # NOTE@jsjoeio - this script assumes that you've downloaded
   # the release-packages artifact to ./release-packages before


### PR DESCRIPTION
This PR _should_ fix the `brew-bump` script that runs when we publish releases.

## Testing

I tested this in a separate PR with the `--dry-run` flag and [received no errors](https://github.com/coder/code-server/runs/5667729416?check_suite_focus=true#step:3:182). I didn't try without `--dry-run` but can separately if requested.

Here is how I tested: https://github.com/coder/code-server/pull/5023/files 

Fixes #4950 
