### PR TITLE
chore(rennovate): ignore updates for express

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,6 @@
   ],
   "vulnerabilityAlerts": {
     "enabled": "true"
-  }
+  },
+  "ignoreDeps": ["express"]
 }


### PR DESCRIPTION
Disables auto-updates of `express` dependency so things like https://github.com/coder/code-server/pull/5013 don't happen.

Fixes N/A
