### PR TITLE
docs(helm): add required env for docker-in-docker

### DIFF
--- a/ci/helm-chart/values.yaml
+++ b/ci/helm-chart/values.yaml
@@ -70,6 +70,8 @@ extraArgs: []
 extraVars: []
 #  - name: DISABLE_TELEMETRY
 #    value: true
+#  - name: DOCKER_HOST
+#    value: "tcp://localhost:2375"
 
 ##
 ## Init containers parameters:
@@ -126,6 +128,7 @@ persistence:
 ## Enable an Specify container in extraContainers.
 ## This is meant to allow adding code-server dependencies, like docker-dind.
 extraContainers: |
+# If docker-dind is used, DOCKER_HOST env is mandatory to set in "extraVars"
 #- name: docker-dind
 #  image: docker:19.03-dind
 #  imagePullPolicy: IfNotPresent


### PR DESCRIPTION
<!--

Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes #199
Hi, I see there's an example of docker in docker in `extraContainers` 
but in order to use it, you need to set `DOCKER_HOST` in code-server too

I think it a good idea to add more since we already had dind in `extraContainers` 

Working in my RKE cluster v1.21.10