### PR TITLE
chore(ci): disable docs-preview on forks

### DIFF
--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -30,6 +30,9 @@ jobs:
 
       - name: Comment Credentials
         uses: marocchino/sticky-pull-request-comment@v2
+        # Only run if PR comes from base repo
+        # Reason: forks cannot access secrets and this will always fail
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           GITHUB_TOKEN: ${{ github.token }}
           header: codercom-preview-docs


### PR DESCRIPTION
Sadly, https://github.com/coder/code-server/pull/5042 did not fix the issue with forks. Disabling until myself or @BrunoQuaresma has time to look into this.

Fixes N/A
