### PR TITLE
fix(npm): write npm package name to file

### DIFF
--- a/ci/steps/publish-npm.sh
+++ b/ci/steps/publish-npm.sh
@@ -137,7 +137,10 @@ main() {
     # Use the development package name
     # This is so we don't clutter the code-server versions on npm
     # with development versions.
-    jq ".name |= \"$PACKAGE_NAME\"" package.json
+    # jq can't edit in place so we must store in memory and echo
+    local contents
+    contents="$(jq ".name |= \"$PACKAGE_NAME\"" package.json)"
+    echo "${contents}" > package.json
     popd
   fi
 


### PR DESCRIPTION
Accidentally [removed the part](https://github.com/coder/code-server/pull/4972/commits/c2c78456d0cedb029e7dc4a772b82f25a22ddde1) that writes the `jq` change to the `package.json` which means we weren't actually publishing to `@coder/code-server-pr`. Oops. 

Fixes N/A
