### PR TITLE
fix: Exclude .deb files from release Docker image

### DIFF
--- a/ci/release-image/Dockerfile
+++ b/ci/release-image/Dockerfile
@@ -1,3 +1,8 @@
+# syntax=docker/dockerfile:experimental
+
+FROM scratch AS packages
+COPY release-packages/code-server*.deb /tmp/
+
 FROM debian:11
 
 RUN apt-get update \
@@ -34,9 +39,8 @@ RUN ARCH="$(dpkg --print-architecture)" && \
     mkdir -p /etc/fixuid && \
     printf "user: coder\ngroup: coder\n" > /etc/fixuid/config.yml
 
-COPY release-packages/code-server*.deb /tmp/
 COPY ci/release-image/entrypoint.sh /usr/bin/entrypoint.sh
-RUN dpkg -i /tmp/code-server*$(dpkg --print-architecture).deb && rm /tmp/code-server*.deb
+RUN --mount=from=packages,src=/tmp,dst=/tmp/packages dpkg -i /tmp/packages/code-server*$(dpkg --print-architecture).deb
 
 EXPOSE 8080
 # This way, if someone sets $DOCKER_USER, docker-exec will still work as


### PR DESCRIPTION
Currently, the `codercom/code-server` Docker image includes a copy of the release's .deb package files, even though they're only used in an intermediate layer. What's more, it includes packages from every architecture, not just the one being released.

This patch fixes this by updating the Dockerfile to use a multi-stage build. First, the packages are copied from the local build context into a temporary directory in a "scratch" build stage. Then, this directory is mounted into the main build, so that the appropriate .deb file can be installed without ever being actually stored in the image.

In my testing (with the 4.2.0 packages for linux-amd64) this reduces the total compressed and uncompressed size by a fairly substantial amount:

| | Before | After | Change |
| --- | ---: | ---: | ---: |
| compressed | 637 MB | 268 MB | -58% |
| uncompressed | 1094 MB | 724 MB | -34% |

Partially fixes #4112
