### PR TITLE
docs: simplify termux installation process

### DIFF
--- a/docs/termux.md
+++ b/docs/termux.md
@@ -90,7 +90,7 @@ To create a new user follow these simple steps -
 2. Change the password by running `passwd <username>`.
 3. Give your new user sudo access by running `visudo`, scroll down to `User privilege specification` and add the following line after root `username ALL=(ALL:ALL) ALL`.
 4. Now edit the `/etc/passwd` file with your command line editor of choice and at the end of the line that specifies your user change `/bin/sh` to `/bin/bash`.
-5. Now switch users, by running `su - <username>`
+5. Now switch users by running `su - <username>`
 
 - Remember the `-` betweeen `su` and username is required to execute `/etc/profile`,\
   since `/etc/profile` may have some necessary things to be executed you should always add a `-`.

--- a/docs/termux.md
+++ b/docs/termux.md
@@ -38,11 +38,12 @@ apt update && apt upgrade -y && apt-get install sudo vim git -y
 
    - Copy the lines NVM asks you to run after running the install script.
    - Run `nano /root/.bashrc` and comment out those lines by adding a `#` at the start.
-   - Run `nano /etc/profile` and paste those lines at the end of the file.  Make sure to replace `$HOME` with `/root` on the first line.
+   - Run `nano /etc/profile` and paste those lines at the end of the file. Make sure to replace `$HOME` with `/root` on the first line.
    - Now run `exit`
    - Start Debian again `proot-distro login debian`
 
 6. After following the instructions and setting up NVM you can now install the [required node version](https://coder.com/docs/code-server/latest/npm#nodejs-version) by running:
+
 ```bash
 nvm install v<major_version_here>
 ```
@@ -154,23 +155,31 @@ eval "$(pyenv virtualenv-init -)"
 ### Working with PRoot
 
 Debian PRoot Distro Dev Environment
+
 - Since Node and code-server are installed in the Debian PRoot distro, your `~/.ssh/` configuration, `~/.bashrc`, git, npm packages, etc. should be setup in PRoot as well.
 - The terminal accessible in code-server will bring up the filesystem and `~/.bashrc` in the Debian PRoot distro.
 
 Accessing files in the Debian PRoot Distro
+
 - The `/data/data/com.termux/files/home` directory in PRoot accesses the termux home directory (`~`)
 - The `/sdcard` directory in PRoot accesses the Android storage directory, though there are [known issues with git and files in the `/sdcard` path](#git-wont-work-in-sdcard)
 
 Accessing the Debian PRoot distro/Starting code-server
+
 - Run the following command to access the Debian PRoot distro, from the termux shell:
+
 ```bash
 proot-distro login debian
 ```
+
 - Run the following command to start code-server directly in the Debian PRoot distro, from the termux shell:
+
 ```bash
 proot-distro login debian -- code-server
 ```
+
 - If you [created a new user](#create-a-new-user), you'll need to insert the `--user <username>` option between `login` and `debian` in the commands above to run as the user instead of root in PRoot.
 
 Additional information on PRoot and Termux
+
 - Additional information on using your Debian PRoot Distro can be [found here](https://github.com/termux/proot-distro#functionality-overview).

--- a/docs/termux.md
+++ b/docs/termux.md
@@ -89,7 +89,7 @@ To create a new user follow these simple steps -
 1. Create a new user by running `useradd <username> -m`.
 2. Change the password by running `passwd <username>`.
 3. Give your new user sudo access by running `visudo`, scroll down to `User privilege specification` and add the following line after root `username ALL=(ALL:ALL) ALL`.
-4. Now edit the `/etc/passwd` file with your commandline editor of choice and at the end of the line that specifies your user change `/bin/sh` to `/bin/bash`.
+4. Now edit the `/etc/passwd` file with your command line editor of choice and at the end of the line that specifies your user change `/bin/sh` to `/bin/bash`.
 5. Now switch users, by running `su - <username>`
 
 - Remember the `-` betweeen `su` and username is required to execute `/etc/profile`,\

--- a/docs/termux.md
+++ b/docs/termux.md
@@ -19,7 +19,7 @@
 1. Get [Termux](https://f-droid.org/en/packages/com.termux/) from **F-Droid**.
 2. Install Debian by running the following:
    - Run `termux-setup-storage` to allow storage access, or else code-server won't be able to read from `/sdcard`.\
-     > The following command is from [proot-distro](https://github.com/termux/proot-distro) you can also use [Andronix](https://andronix.app/).
+     > The following command is from [proot-distro](https://github.com/termux/proot-distro), but you can also use [Andronix](https://andronix.app/).
      > After Debian is installed the `~ $` will change to `root@localhost`.
 
 ```bash

--- a/docs/termux.md
+++ b/docs/termux.md
@@ -29,7 +29,7 @@ pkg up -y && pkg in proot-distro -y && proot-distro install debian && proot-dist
 3. Run the following commands to setup Debian:
 
 ```bash
-apt update && apt upgrade -y && apt-get install git -y
+apt update && apt upgrade -y && apt-get install sudo vim git -y
 ```
 
 4. Install [NVM](https://github.com/nvm-sh/nvm#install--update-script) by following the install guide in the README, just a curl/wget command.

--- a/docs/termux.md
+++ b/docs/termux.md
@@ -23,7 +23,7 @@
      > After Debian is installed the `~ $` will change to `root@localhost`.
 
 ```bash
-pkg up -y && pkg in proot-distro -y && proot-distro install debian && proot-distro login debian
+pkg update -y && pkg install proot-distro -y && proot-distro install debian && proot-distro login debian
 ```
 
 3. Run the following commands to setup Debian:

--- a/docs/termux.md
+++ b/docs/termux.md
@@ -10,40 +10,44 @@
   - [Create a new user](#create-a-new-user)
   - [Install Go](#install-go)
   - [Install Python](#install-python)
+  - [Working with PRoot](#working-with-proot)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Install
 
 1. Get [Termux](https://f-droid.org/en/packages/com.termux/) from **F-Droid**.
-2. Install Debian by running the following.
+2. Install Debian by running the following:
    - Run `termux-setup-storage` to allow storage access, or else code-server won't be able to read from `/sdcard`.\
-      If you used the Andronix command then you may have to edit the `start-debian.sh` script to mount `/sdcard` just as simple as uncommenting the `command+=" -b /sdcard"` line.
-     > The following command was extracted from [Andronix](https://andronix.app/) you can also use [proot-distro](https://github.com/termux/proot-distro).
+     > The following command is from [proot-distro](https://github.com/termux/proot-distro) you can also use [Andronix](https://andronix.app/).
      > After Debian is installed the `~ $` will change to `root@localhost`.
 
 ```bash
-pkg update -y && pkg install wget curl proot tar -y && wget https://raw.githubusercontent.com/AndronixApp/AndronixOrigin/master/Installer/Debian/debian.sh -O debian.sh && chmod +x debian.sh && bash debian.sh
+pkg up -y && pkg in proot-distro -y && proot-distro install debian && proot-distro login debian
 ```
 
-3. Run the following commands to setup Debian.
+3. Run the following commands to setup Debian:
 
 ```bash
-apt update
-apt upgrade -y
-apt-get install nano vim sudo curl wget git -y
+apt update && apt upgrade -y && apt-get install git -y
 ```
 
-4. Install [NVM](https://github.com/nvm-sh/nvm) by following the install guide in the README, just a curl/wget command.
-5. Set up NVM for multi-user. After installing NVM it automatically adds the necessary commands for it to work, but it will only work if you are logged in as root;
+4. Install [NVM](https://github.com/nvm-sh/nvm#install--update-script) by following the install guide in the README, just a curl/wget command.
+
+5. Set up NVM for multi-user. After installing NVM it automatically adds the necessary commands for it to work, but it will only work if you are logged in as root:
 
    - Copy the lines NVM asks you to run after running the install script.
    - Run `nano /root/.bashrc` and comment out those lines by adding a `#` at the start.
-   - Run `nano /etc/profile` and paste those lines at the end and make sure to replace `$HOME` with `/root`
-   - Now run `exit` and start Debain again.
+   - Run `nano /etc/profile` and paste those lines at the end of the file.  Make sure to replace `$HOME` with `/root` on the first line.
+   - Now run `exit`
+   - Start Debian again `proot-distro login debian`
 
-6. After following the instructions and setting up NVM you can now install the [required node version](https://coder.com/docs/code-server/latest/npm#nodejs-version) using `nvm install version_here`.
-7. To install `code-server` run the following.
+6. After following the instructions and setting up NVM you can now install the [required node version](https://coder.com/docs/code-server/latest/npm#nodejs-version) by running:
+```bash
+nvm install v<major_version_here>
+```
+
+7. To install `code-server` run the following:
    > To check the install process (Will not actually install code-server)
    > If it all looks good, you can install code-server by running the second command
 
@@ -82,11 +86,11 @@ Potential Workaround :
 
 To create a new user follow these simple steps -
 
-1. Create a new user by running `useradd username -m`.
-2. Change the password by running `passwd username`.
-3. Give your new user sudo access by runnning `visudo`, scroll down to `User privilege specification` and add the following line after root `username ALL=(ALL:ALL) ALL`.
-4. Now edit the `/etc/passwd` file with your commadline editor of choice and at the end of the line that specifies your user change `/bin/sh` to `/bin/bash`.
-5. Now switch users, by running `su - username`
+1. Create a new user by running `useradd <username> -m`.
+2. Change the password by running `passwd <username>`.
+3. Give your new user sudo access by running `visudo`, scroll down to `User privilege specification` and add the following line after root `username ALL=(ALL:ALL) ALL`.
+4. Now edit the `/etc/passwd` file with your commandline editor of choice and at the end of the line that specifies your user change `/bin/sh` to `/bin/bash`.
+5. Now switch users, by running `su - <username>`
 
 - Remember the `-` betweeen `su` and username is required to execute `/etc/profile`,\
   since `/etc/profile` may have some necessary things to be executed you should always add a `-`.
@@ -95,7 +99,7 @@ To create a new user follow these simple steps -
 
 > From https://golang.org/doc/install
 
-1. Go to https://golang.org/dl/ and copy the download link for `linux arm` and run the following.
+1. Go to https://golang.org/dl/ and copy the download link for `linux arm` and run the following:
 
 ```bash
 wget download_link
@@ -115,7 +119,7 @@ rm -rf /usr/local/go && tar -C /usr/local -xzf archive_name
 
 > Run these commands as root
 
-1. Run the following command to install required packages to build python.
+1. Run the following commands to install required packages to build python:
 
 ```bash
 sudo apt-get update
@@ -124,13 +128,13 @@ sudo apt-get install make build-essential libssl-dev zlib1g-dev \
   libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
 ```
 
-2. Install [pyenv](https://github.com/pyenv/pyenv/) from [pyenv-installer](https://github.com/pyenv/pyenv-installer) by running.
+2. Install [pyenv](https://github.com/pyenv/pyenv/) from [pyenv-installer](https://github.com/pyenv/pyenv-installer) by running:
 
 ```bash
 curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
 ```
 
-3. Run `nano /etc/profile` and add the following
+3. Run `nano /etc/profile` and add the following:
 
 ```bash
 export PYENV_ROOT="/root/.pyenv"
@@ -139,10 +143,34 @@ eval "$(pyenv init --path)"
 eval "$(pyenv virtualenv-init -)"
 ```
 
-4. Exit start Debian again.
+4. Exit and start Debian again.
 5. Run `pyenv versions` to list all installable versions.
 6. Run `pyenv install version` to install the desired python version.
    > The build process may take some time (an hour or 2 depending on your device).
 7. Run `touch /root/.pyenv/version && echo "your_version_here" > /root/.pyenv/version`
 8. (You may have to start Debian again) Run `python3 -V` to verify if PATH works or not.
    > If `python3` doesn't work but pyenv says that the install was successful in step 6 then try running `$PYENV_ROOT/versions/your_version/bin/python3`.
+
+### Working with PRoot
+
+Debian PRoot Distro Dev Environment
+- Since Node and code-server are installed in the Debian PRoot distro, your `~/.ssh/` configuration, `~/.bashrc`, git, npm packages, etc. should be setup in PRoot as well.
+- The terminal accessible in code-server will bring up the filesystem and `~/.bashrc` in the Debian PRoot distro.
+
+Accessing files in the Debian PRoot Distro
+- The `/data/data/com.termux/files/home` directory in PRoot accesses the termux home directory (`~`)
+- The `/sdcard` directory in PRoot accesses the Android storage directory, though there are [known issues with git and files in the `/sdcard` path](#git-wont-work-in-sdcard)
+
+Accessing the Debian PRoot distro/Starting code-server
+- Run the following command to access the Debian PRoot distro, from the termux shell:
+```bash
+proot-distro login debian
+```
+- Run the following command to start code-server directly in the Debian PRoot distro, from the termux shell:
+```bash
+proot-distro login debian -- code-server
+```
+- If you [created a new user](#create-a-new-user), you'll need to insert the `--user <username>` option between `login` and `debian` in the commands above to run as the user instead of root in PRoot.
+
+Additional information on PRoot and Termux
+- Additional information on using your Debian PRoot Distro can be [found here](https://github.com/termux/proot-distro#functionality-overview).


### PR DESCRIPTION
1) Updated information to use PRoot (simpler than Andronix and the way supported by Termux) to create and access the Debian distro.
2) Added helpful information on using PRoot with your dev environment.
3) Cleaned up spelling, grammar, and made documentation more consistent between sections.

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes #
