### PR TITLE
revert(docs): partially revert 326a1d1862872955cec062030df2bd103799a1eb

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -57,7 +57,7 @@ body:
     id: logs
     attributes:
       label: Logs
-      description: Run code-server with the --verbose flag and then paste any relevant logs from the server, from the browser console and/or the browser network tab. For issues with installation, include installation logs (i.e. output of `npm install -g code-server`).
+      description: Run code-server with the --verbose flag and then paste any relevant logs from the server, from the browser console and/or the browser network tab. For issues with installation, include installation logs (i.e. output of `yarn global add code-server`).
   - type: textarea
     attributes:
       label: Screenshot/Video

--- a/ci/steps/publish-npm.sh
+++ b/ci/steps/publish-npm.sh
@@ -59,11 +59,11 @@ main() {
   # This string is used to determine how we should tag the npm release.
   # Environment can be one of three choices:
   # "development" - this means we tag with the PR number, allowing
-  # a developer to install this version with `npm install code-server@<pr-number>`
+  # a developer to install this version with `yarn add code-server@<pr-number>`
   # "staging" - this means we tag with `beta`, allowing
-  # a developer to install this version with `npm install code-server@beta`
+  # a developer to install this version with `yarn add code-server@beta`
   # "production" - this means we tag with `latest` (default), allowing
-  # a developer to install this version with `npm install code-server@latest`
+  # a developer to install this version with `yarn add code-server@latest`
   if ! is_env_var_set "NPM_ENVIRONMENT"; then
     echo "NPM_ENVIRONMENT is not set. Determining in script based on GITHUB environment variables."
 
@@ -96,7 +96,7 @@ main() {
   if [[ "$NPM_ENVIRONMENT" == "production" ]]; then
     NPM_VERSION="$VERSION"
     # This means the npm version will be published as "stable"
-    # and installed when a user runs `npm install code-server`
+    # and installed when a user runs `yarn install code-server`
     NPM_TAG="latest"
   else
     COMMIT_SHA="$GITHUB_SHA"
@@ -107,7 +107,7 @@ main() {
     if [[ "$NPM_ENVIRONMENT" == "staging" ]]; then
       NPM_VERSION="$VERSION-beta-$COMMIT_SHA"
       # This means the npm version will be tagged with "beta"
-      # and installed when a user runs `npm install code-server@beta`
+      # and installed when a user runs `yarn install code-server@beta`
       NPM_TAG="beta"
     fi
 
@@ -117,7 +117,7 @@ main() {
       NPM_VERSION="$VERSION-$PR_NUMBER-$COMMIT_SHA"
       PACKAGE_NAME="@coder/code-server-pr"
       # This means the npm version will be tagged with "<pr number>"
-      # and installed when a user runs `npm install code-server@<pr number>`
+      # and installed when a user runs `yarn install code-server@<pr number>`
       NPM_TAG="$PR_NUMBER"
     fi
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -3,7 +3,7 @@
 1. Install UserLAnd from [Google Play](https://play.google.com/store/apps/details?id=tech.ula&hl=en_US&gl=US)
 2. Install an Ubuntu VM
 3. Start app
-4. Install Node.js, `curl` and `npm` using `sudo apt install nodejs npm curl -y`
+4. Install Node.js, `curl` and `yarn` using `sudo apt install nodejs npm yarn curl -y`
 5. Install `nvm`:
 
 ```shell

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,7 +4,7 @@
 
 - [install.sh](#installsh)
   - [Detection reference](#detection-reference)
-- [npm](#npm)
+- [yarn, npm](#yarn-npm)
 - [Standalone releases](#standalone-releases)
 - [Debian, Ubuntu](#debian-ubuntu)
 - [Fedora, CentOS, RHEL, SUSE](#fedora-centos-rhel-suse)
@@ -19,7 +19,7 @@
 - [Uninstall](#uninstall)
   - [install.sh](#installsh-1)
   - [Homebrew](#homebrew)
-  - [npm](#npm-1)
+  - [yarn, npm](#yarn-npm-1)
   - [Debian, Ubuntu](#debian-ubuntu-1)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -87,16 +87,17 @@ _exact_ same commands presented in the rest of this document.
 
   - Ensure that you add `~/.local/bin` to your `$PATH` to run code-server.
 
-- For FreeBSD, code-server will install the [npm package](#npm) with `npm`.
+- For FreeBSD, code-server will install the [npm package](#yarn-npm) with `yarn`
+  or `npm`.
 
 - If you're installing code-server onto architecture with no releases,
-  code-server will install the [npm package](#npm) with `npm`
+  code-server will install the [npm package](#yarn-npm) with `yarn` or `npm`
   - We currently offer releases for amd64 and arm64.
-  - The [npm package](#npm) builds the native modules on post-install.
+  - The [npm package](#yarn-npm) builds the native modules on post-install.
 
-## npm
+## yarn, npm
 
-We recommend installing with `npm` when:
+We recommend installing with `yarn` or `npm` when:
 
 1. You aren't using a machine with `amd64` or `arm64`.
 1. You are installing code-server on Windows
@@ -106,9 +107,9 @@ We recommend installing with `npm` when:
    [#1430](https://github.com/coder/code-server/issues/1430#issuecomment-629883198)
    for more information.
 
-Installing code-server with `npm` builds native modules on install.
+Installing code-server with `yarn` or `npm` builds native modules on install.
 
-This process requires C dependencies; see our guide on [installing with `npm`][./npm.md](./npm.md) for more information.
+This process requires C dependencies; see our guide on [installing with yarn and npm][./npm.md](./npm.md) for more information.
 
 ## Standalone releases
 
@@ -116,7 +117,7 @@ We publish self-contained `.tar.gz` archives for every release on
 [GitHub](https://github.com/coder/code-server/releases). The archives bundle the
 node binary and node modules.
 
-We create the standalone releases using the [npm package](#npm), and we
+We create the standalone releases using the [npm package](#yarn-npm), and we
 then create the remaining releases using the standalone version.
 
 The only requirement to use the standalone release is `glibc` >= 2.17 and
@@ -150,7 +151,7 @@ code-server
 ## Debian, Ubuntu
 
 > The standalone arm64 .deb does not support Ubuntu 16.04 or earlier. Please
-> upgrade or [build with `npm`](#npm).
+> upgrade or [build with yarn](#yarn-npm).
 
 ```bash
 curl -fOL https://github.com/coder/code-server/releases/download/v$VERSION/code-server_$VERSION_amd64.deb
@@ -162,7 +163,7 @@ sudo systemctl enable --now code-server@$USER
 ## Fedora, CentOS, RHEL, SUSE
 
 > The standalone arm64 .rpm does not support CentOS 7. Please upgrade or [build
-> with `npm`](#npm).
+> with yarn](#yarn-npm).
 
 ```bash
 curl -fOL https://github.com/coder/code-server/releases/download/v$VERSION/code-server-$VERSION-amd64.rpm
@@ -227,13 +228,14 @@ You can install code-server using the [Helm package manager](https://coder.com/d
 
 ## Windows
 
-We currently [do not publish Windows releases](https://github.com/coder/code-server/issues/1397). We recommend installing code-server onto Windows with [`npm`](#npm).
+We currently [do not publish Windows releases](https://github.com/coder/code-server/issues/1397). We recommend installing code-server onto Windows with [`yarn` or `npm`](#yarn-npm).
 
 > Note: You will also need to [build coder/cloud-agent manually](https://github.com/coder/cloud-agent/issues/17) if you would like to use `code-server --link` on Windows.
 
 ## Raspberry Pi
 
-We recommend installing code-server onto Raspberry Pi with [`npm`](#npm).
+We recommend installing code-server onto Raspberry Pi with [`yarn` or
+`npm`](#yarn-npm).
 
 ## Termux
 
@@ -275,9 +277,15 @@ brew remove code-server
 brew uninstall code-server
 ```
 
-### npm
+### yarn, npm
 
 To remove the code-server global module, run:
+
+```shell
+yarn global remove code-server
+```
+
+or
 
 ```shell
 npm uninstall -g code-server

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -21,7 +21,7 @@
       "children": [
         {
           "title": "npm",
-          "description": "How to install code-server using npm",
+          "description": "How to install code-server using npm or yarn",
           "path": "./npm.md"
         },
         {

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -20,11 +20,6 @@ If you're installing code-server via `npm`, you'll need to install additional
 dependencies required to build the native modules used by VS Code. This article
 includes installing instructions based on your operating system.
 
-> **WARNING**: Do not use `yarn` to install code-server. Unlike `npm`, it does not respect
-> lockfiles for distributed applications. It will instead use the latest version
-> available at installation time - which might not be the one used for a given
-> code-server release, and [might lead to unexpected behavior](https://github.com/coder/code-server/issues/4927).
-
 ## Node.js version
 
 We use the same major version of Node.js shipped with VSCode's Electron,
@@ -77,7 +72,7 @@ Proceed to [installing](#installing)
 ## FreeBSD
 
 ```sh
-pkg install -y git python npm-node14 pkgconf
+pkg install -y git python npm-node14 yarn-node14 pkgconf
 pkg install -y libinotify
 ```
 
@@ -90,7 +85,8 @@ Installing code-server requires all of the [prerequisites for VS Code developmen
 Next, install code-server with:
 
 ```bash
-npm install -g code-server
+yarn global add code-server
+# Or: npm install -g code-server
 code-server
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```
@@ -100,7 +96,8 @@ A `postinstall.sh` script will attempt to run. Select your terminal (e.g., Git b
 If the `code-server` command is not found, you'll need to [add a directory to your PATH](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/). To find the directory, use the following command:
 
 ```shell
-npm config get prefix
+yarn global bin
+# Or: npm config get prefix
 ```
 
 For help and additional troubleshooting, see [#1397](https://github.com/coder/code-server/issues/1397).
@@ -110,7 +107,8 @@ For help and additional troubleshooting, see [#1397](https://github.com/coder/co
 After adding the dependencies for your OS, install the code-server package globally:
 
 ```bash
-npm install -g code-server
+yarn global add code-server
+# Or: npm install -g code-server
 code-server
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```
@@ -124,7 +122,7 @@ page](https://github.com/coder/code-server/discussions).
 
 Occasionally, you may run into issues with Node.js.
 
-If you install code-server using `npm`, and you upgrade your Node.js
+If you install code-server using `yarn` or `npm`, and you upgrade your Node.js
 version, you may need to reinstall code-server to recompile native modules.
 Sometimes, you can get around this by navigating into code-server's `lib/vscode`
 directory and running `npm rebuild` to recompile the modules.
@@ -138,7 +136,7 @@ A step-by-step example of how you might do this is:
 
 ### Debugging install issues with npm
 
-To debug installation issues:
+`yarn` suppresses logs when running `yarn global add`, so to debug installation issues, install with `npm` instead:
 
 ```shell
 # Uninstall


### PR DESCRIPTION
We tried to switch from `yarn` to `npm` because `yarn` ignores lockfiles
but learned that we missed a few key things.

For now, we are reverting docs and a few other changes that suggested
using `npm` instead of `yarn` until we fully remove `yarn` from the
codebase.

Related to https://github.com/coder/code-server/pull/5071
