### PR TITLE
release: 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [9.99.999] - 9090-09-09
 
-VS Code v99.99.999
+Code v99.99.999
 
-### Changed
 ### Added
+### Changed
 ### Deprecated
 ### Removed
 ### Fixed
 ### Security
 
 -->
+
+## [4.3.0](https://github.com/coder/code-server/releases/tag/v4.3.0) -
+
+#2022-04-13
+
+Code v1.65.2
+
+### Changed
+
+- Excluded .deb files from release Docker image which drops the compressed and
+  uncompressed size by 58% and 34%. - Upgraded to Code 1.65.2.
+
+### Added
+
+- Added a new CLI flag called `--disable-file-downloads` which allows you to
+  disable the "Download..." option that shows in the UI when right-clicking on a
+  file. This can also set by running `CS_DISABLE_FILE_DOWNLOADS=1`. - Aligned the
+  dependencies for binary and npm release artifacts.
+
+### Fixed
+
+- Fixed the code-server version from not displaying in the Help > About dialog.
+- Fixed issues with the TypeScript and JavaScript Language Features Extension
+  failing to activate. - Fixed missing files in ipynb extension. - Fixed the
+  homebrew release workflow. - Fixed the Docker release workflow from not always
+  publishing version tags.
 
 ## [4.2.0](https://github.com/coder/code-server/releases/tag/v4.2.0) - 2022-03-22
 

--- a/ci/build/npm-postinstall.sh
+++ b/ci/build/npm-postinstall.sh
@@ -24,7 +24,7 @@ export npm_config_build_from_source=true
 
 main() {
   # Grabs the major version of node from $npm_config_user_agent which looks like
-  # yarn/1.21.1 npm/? node/v14.2.0 darwin x64
+  # yarn/1.21.1 npm/? node/v14.3.0 darwin x64
   major_node_version=$(echo "$npm_config_user_agent" | sed -n 's/.*node\/v\([^.]*\).*/\1/p')
 
   if [ -n "${FORCE_NODE_VERSION:-}" ]; then

--- a/ci/build/release-prep.sh
+++ b/ci/build/release-prep.sh
@@ -81,7 +81,7 @@ main() {
   read -r -p "What version of code-server do you want to update to?"$'\n' CODE_SERVER_VERSION_TO_UPDATE
 
   echo -e "Great! We'll prep a PR for updating to $CODE_SERVER_VERSION_TO_UPDATE\n"
-  $CMD rg -g '!yarn.lock' -g '!*.svg' -g '!CHANGELOG.md' --files-with-matches --fixed-strings "${CODE_SERVER_CURRENT_VERSION}" | $CMD xargs sd "$CODE_SERVER_CURRENT_VERSION" "$CODE_SERVER_VERSION_TO_UPDATE"
+  $CMD rg -g '!yarn.lock' -g '!*.svg' -g '!CHANGELOG.md' -g '!lib/vscode/**' --files-with-matches --fixed-strings "${CODE_SERVER_CURRENT_VERSION}" | $CMD xargs sd "$CODE_SERVER_CURRENT_VERSION" "$CODE_SERVER_VERSION_TO_UPDATE"
 
   $CMD git commit --no-verify -am "chore(release): bump version to $CODE_SERVER_VERSION_TO_UPDATE"
 

--- a/ci/helm-chart/Chart.yaml
+++ b/ci/helm-chart/Chart.yaml
@@ -20,4 +20,4 @@ version: 2.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.2.0
+appVersion: 4.3.0

--- a/ci/helm-chart/values.yaml
+++ b/ci/helm-chart/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: codercom/code-server
-  tag: '4.2.0'
+  tag: '4.3.0'
   pullPolicy: Always
 
 # Specifies one or more secrets to be used when pulling images from a

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -164,7 +164,7 @@ If you're the current release manager, follow these steps:
 
 ### Publishing a release
 
-1. Create a new branch called `v0.0.0` (replace 0s with actual version aka v4.2.0)
+1. Create a new branch called `v0.0.0` (replace 0s with actual version aka v4.3.0)
 1. Run `yarn release:prep` and type in the new version (e.g., `3.8.1`)
 1. GitHub Actions will generate the `npm-package`, `release-packages` and
    `release-images` artifacts. You do not have to wait for this step to complete

--- a/docs/collaboration.md
+++ b/docs/collaboration.md
@@ -60,6 +60,6 @@ As `code-server` is based on VS Code, you can follow the steps described on Duck
    code-server --enable-proposed-api genuitecllc.codetogether
    ```
 
-   Another option would be to add a value in code-server's [config file](https://coder.com/docs/code-server/v4.2.0/FAQ#how-does-the-config-file-work).
+   Another option would be to add a value in code-server's [config file](https://coder.com/docs/code-server/v4.3.0/FAQ#how-does-the-config-file-work).
 
 3. Refresh code-server and navigate to the CodeTogether icon in the sidebar to host or join a coding session.

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -1,6 +1,6 @@
 # code-server Helm Chart
 
-[![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) [![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![AppVersion: 4.2.0](https://img.shields.io/badge/AppVersion-4.2.0-informational?style=flat-square)](https://img.shields.io/badge/AppVersion-4.2.0-informational?style=flat-square)
+[![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) [![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![AppVersion: 4.3.0](https://img.shields.io/badge/AppVersion-4.3.0-informational?style=flat-square)](https://img.shields.io/badge/AppVersion-4.3.0-informational?style=flat-square)
 
 [code-server](https://github.com/coder/code-server) code-server is VS Code running
 on a remote server, accessible through the browser.
@@ -73,7 +73,7 @@ and their default values.
 | hostnameOverride                            | string | `""`                     |
 | image.pullPolicy                            | string | `"Always"`               |
 | image.repository                            | string | `"codercom/code-server"` |
-| image.tag                                   | string | `"4.2.0"`                |
+| image.tag                                   | string | `"4.3.0"`                |
 | imagePullSecrets                            | list   | `[]`                     |
 | ingress.enabled                             | bool   | `false`                  |
 | nameOverride                                | string | `""`                     |

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,5 +1,5 @@
 {
-  "versions": ["v4.2.0"],
+  "versions": ["v4.3.0"],
   "routes": [
     {
       "title": "Home",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-server",
   "license": "MIT",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Run VS Code on a remote server.",
   "homepage": "https://github.com/coder/code-server",
   "bugs": {


### PR DESCRIPTION
<!-- Note: this variable $CODE_SERVER_VERSION_TO_UPDATE will be set when you run the release-prep.sh script with `yarn release:prep` -->

This PR is to generate a new release of `code-server` at `4.3.0`

## Screenshot

_npm build_: tested on coder and works as expected 👍🏼
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/3806031/163265414-d4a807e2-f642-462e-9122-51715e87201f.png">

## TODOs

Follow "Publishing a release" steps in `ci/README.md`

<!-- Note some of these steps below are redundant since they're listed in the "Publishing a release" docs -->
- [x] test npm build
- [ ] test built-in extensions
- [ ] publish release and merge PR
- [ ] update the AUR package


Fixes #5021