### PR TITLE
fix: skip flaky update test

### DIFF
--- a/test/unit/node/update.test.ts
+++ b/test/unit/node/update.test.ts
@@ -122,7 +122,8 @@ describe("update", () => {
     spy = []
   })
 
-  it("should get the latest", async () => {
+  // TODO@jsjoeio: rewrite this test so it's not flaky
+  it.skip("should get the latest", async () => {
     version = "2.1.0"
 
     const p = provider()


### PR DESCRIPTION
I've noticed this test fail multiple times. I think we should skip it until we set aside time to rewrite it.

Evidence: https://github.com/coder/code-server/runs/5999223188?check_suite_focus=true#step:12:13

Fixes N/A
