### PR TITLE
chore: attempt to fix docker

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -43,10 +43,9 @@ jobs:
         uses: robinraju/release-downloader@v1.3
         with:
           repository: "coder/code-server"
-          tag: "v4.3.0"
-          fileName: "*"
+          tag: v${{ steps.version.outputs.version }}
+          fileName: "*.deb"
           out-file-path: "release-packages"
-          path: "release-packages"
 
       - name: Run ./ci/steps/docker-buildx-push.sh
         run: ./ci/steps/docker-buildx-push.sh

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -47,7 +47,7 @@ jobs:
           fileName: "*.deb"
           out-file-path: "release-packages"
 
-      - name: Run ./ci/steps/docker-buildx-push.sh
-        run: ./ci/steps/docker-buildx-push.sh
+      - name: Publish to Docker
+        run: yarn publish:docker
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -39,15 +39,14 @@ jobs:
         id: version
         run: echo "::set-output name=version::$(jq -r .version package.json)"
 
-      - name: Download artifact
-        uses: dawidd6/action-download-artifact@v2
-        id: download
+      - name: Download release artifacts
+        uses: robinraju/release-downloader@v1.3
         with:
-          branch: v${{ steps.version.outputs.version }}
-          workflow: ci.yaml
-          workflow_conclusion: completed
-          name: "release-packages"
-          path: release-packages
+          repository: "coder/code-server"
+          tag: "v4.3.0"
+          fileName: "*"
+          out-file-path: "release-packages"
+          path: "release-packages"
 
       - name: Run ./ci/steps/docker-buildx-push.sh
         run: ./ci/steps/docker-buildx-push.sh

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "package": "./ci/build/build-packages.sh",
     "postinstall": "./ci/dev/postinstall.sh",
     "publish:npm": "./ci/steps/publish-npm.sh",
+    "publish:docker": "./ci/steps/docker-buildx-push.sh",
     "_audit": "./ci/dev/audit.sh",
     "fmt": "./ci/dev/fmt.sh",
     "lint": "./ci/dev/lint.sh",


### PR DESCRIPTION
We had an issue publishing v4.0.3 where the action couldn't find the artifacts to download. This changes that flow to download the release assets from the release for the Docker workflow.