### PR TITLE
chore: provide details when `update.checked` tests fail

### DIFF
--- a/test/unit/node/update.test.ts
+++ b/test/unit/node/update.test.ts
@@ -145,7 +145,7 @@ describe("update", () => {
 
     await expect(settings().read()).resolves.toEqual({ update })
     expect(isNaN(update.checked)).toStrictEqual(false)
-    expect(update.checked < now).toBe(true)
+    expect(update.checked).toBeLessThan(now)
     expect(update.version).toStrictEqual("2.1.0")
     expect(spy).toEqual([])
   })
@@ -159,7 +159,8 @@ describe("update", () => {
 
     await expect(settings().read()).resolves.toEqual({ update })
     expect(isNaN(update.checked)).toStrictEqual(false)
-    expect(update.checked < Date.now() && update.checked >= now).toStrictEqual(true)
+    expect(update.checked).toBeGreaterThanOrEqual(now)
+    expect(update.checked).toBeLessThan(Date.now())
     expect(update.version).toStrictEqual("4.1.1")
     expect(spy).toStrictEqual(["/latest"])
   })
@@ -204,14 +205,16 @@ describe("update", () => {
     let now = Date.now()
     let update = await provider.getUpdate(true)
     expect(isNaN(update.checked)).toStrictEqual(false)
-    expect(update.checked < Date.now() && update.checked >= now).toEqual(true)
+    expect(update.checked).toBeGreaterThanOrEqual(now)
+    expect(update.checked).toBeLessThan(Date.now())
     expect(update.version).toStrictEqual("unknown")
 
     provider = new UpdateProvider("http://probably.invalid.dev.localhost/latest", settings())
     now = Date.now()
     update = await provider.getUpdate(true)
     expect(isNaN(update.checked)).toStrictEqual(false)
-    expect(update.checked < Date.now() && update.checked >= now).toEqual(true)
+    expect(update.checked).toBeGreaterThanOrEqual(now)
+    expect(update.checked).toBeLessThan(Date.now())
     expect(update.version).toStrictEqual("unknown")
   })
 


### PR DESCRIPTION
Using the toBe* functions will let us know what the actual values are
rather than just telling us true does not equal false.

Hopefully when this flakes again this helps us devise a fix.