### PR TITLE
feat(cli): support true for CS_DISABLE_FILE_DOWNLOADS

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -542,7 +542,7 @@ export async function setDefaults(cliArgs: UserProvidedArgs, configArgs?: Config
     args.password = process.env.PASSWORD
   }
 
-  if (process.env.CS_DISABLE_FILE_DOWNLOADS === "1") {
+  if (process.env.CS_DISABLE_FILE_DOWNLOADS?.match(/^(1|true)$/)) {
     args["disable-file-downloads"] = true
   }
 

--- a/test/unit/node/cli.test.ts
+++ b/test/unit/node/cli.test.ts
@@ -362,6 +362,18 @@ describe("parser", () => {
     })
   })
 
+  it("should use env var CS_DISABLE_FILE_DOWNLOADS set to true", async () => {
+    process.env.CS_DISABLE_FILE_DOWNLOADS = "true"
+    const args = parse([])
+    expect(args).toEqual({})
+
+    const defaultArgs = await setDefaults(args)
+    expect(defaultArgs).toEqual({
+      ...defaults,
+      "disable-file-downloads": true,
+    })
+  })
+
   it("should error if password passed in", () => {
     expect(() => parse(["--password", "supersecret123"])).toThrowError(
       "--password can only be set in the config file or passed in via $PASSWORD",


### PR DESCRIPTION
After some feedback, we realized it is more intuitive to disable file
downloads by setting the environment variable
`CS_DISABLE_FILE_DOWNLOADS` to `true` than `1`. This commit adds support
for both.

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes N/A
