### PR TITLE
chore: configure git globally for brew publish

### DIFF
--- a/.github/workflows/npm-brew.yaml
+++ b/.github/workflows/npm-brew.yaml
@@ -60,8 +60,8 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name cdrci
-          git config user.email opensource@coder.com
+          git config --global user.name cdrci
+          git config --global user.email opensource@coder.com
 
       - name: Bump code-server homebrew version
         env:


### PR DESCRIPTION
This should fix this issue we ran into with the 4.4.0 release.

https://github.com/coder/code-server/runs/6329089421?check_suite_focus=true#step:5:182