### PR TITLE
fix: Docker push

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -44,7 +44,7 @@ jobs:
         with:
           repository: "coder/code-server"
           tag: v${{ steps.version.outputs.version }}
-          fileName: "*.deb"
+          fileName: "*"
           out-file-path: "release-packages"
 
       - name: Publish to Docker


### PR DESCRIPTION
The action actually does not support wildcards but it does support * for
downloading all artifacts.