### PR TITLE
feat: add test for isFile when error

### DIFF
--- a/test/unit/node/util.test.ts
+++ b/test/unit/node/util.test.ts
@@ -446,6 +446,9 @@ describe("isFile", () => {
   it("should return true if is file", async () => {
     expect(await util.isFile(pathToFile)).toBe(true)
   })
+  it("should return false if error", async () => {
+    expect(await util.isFile("fakefile.txt")).toBe(false)
+  })
 })
 
 describe("humanPath", () => {


### PR DESCRIPTION
This adds an additional test for the `isFile` utility function to ensure
it returns `false` in the event of an error.

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Related to #5153 [#5149](https://github.com/coder/code-server/issues/5149)
