### PR TITLE
refactor(util): remove unused isObject function

### DIFF
--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -435,10 +435,6 @@ export const buildAllowedMessage = (t: any): string => {
   return `Allowed value${values.length === 1 ? " is" : "s are"} ${values.map((t) => `'${t}'`).join(", ")}`
 }
 
-export const isObject = <T extends object>(obj: T): obj is T => {
-  return !Array.isArray(obj) && typeof obj === "object" && obj !== null
-}
-
 /**
  * Return a promise that resolves with whether the socket path is active.
  */


### PR DESCRIPTION
Jest reported uncovered code for this function block. I did a search and couldn't find it used anywhere so decided we should remove it.
<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Related to #5149 #5153
