### PR TITLE
Fix caddy installation docs

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -126,8 +126,8 @@ access code-server on an iPad or do not want to use SSH port forwarding.
 
 ```console
 sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/cfg/gpg/gpg.155B6D79CA56EA34.key' | sudo apt-key add -
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/cfg/setup/config.deb.txt?distro=debian&version=any-version' | sudo tee -a /etc/apt/sources.list.d/caddy-stable.list
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo apt-key add -
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
 sudo apt update
 sudo apt install caddy
 ```


### PR DESCRIPTION
Applies Caddy installations documentation fixes and also resolves the following issue when trying to install Caddy:

    W: GPG error: https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY ABA1F9B8875A6661

Related Caddy issues: caddyserver/dist#83

Reference to Caddy's docs commit history:

 - https://github.com/caddyserver/website/commit/930109ec3399035c4870a6c6a673537ca4813960
 - https://github.com/caddyserver/website/commit/2e255b1ee39c36919e913466489c205e47a7a8f2
 - https://github.com/caddyserver/website/commit/0f4885e59214a2d08a775051b587bb3363c7453c

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->


