### PR TITLE
fix regex for manifest route

### DIFF
--- a/src/node/routes/vscode.ts
+++ b/src/node/routes/vscode.ts
@@ -170,7 +170,7 @@ export class CodeServerRouteWrapper {
 
   constructor() {
     this.router.get("/", this.ensureCodeServerLoaded, this.$root)
-    this.router.get(/\/manifest\.json$/, this.manifest)
+    this.router.get("/manifest.json", this.manifest)
     this.router.all("*", ensureAuthenticated, this.ensureCodeServerLoaded, this.$proxyRequest)
     this._wsRouterWrapper.ws("*", ensureAuthenticated, this.ensureCodeServerLoaded, this.$proxyWebsocket)
   }

--- a/src/node/routes/vscode.ts
+++ b/src/node/routes/vscode.ts
@@ -170,7 +170,7 @@ export class CodeServerRouteWrapper {
 
   constructor() {
     this.router.get("/", this.ensureCodeServerLoaded, this.$root)
-    this.router.get(/manifest.json$/, this.manifest)
+    this.router.get(/\/manifest\.json$/, this.manifest)
     this.router.all("*", ensureAuthenticated, this.ensureCodeServerLoaded, this.$proxyRequest)
     this._wsRouterWrapper.ws("*", ensureAuthenticated, this.ensureCodeServerLoaded, this.$proxyWebsocket)
   }


### PR DESCRIPTION
I noticed that the regex would match other strings than manifest.json such as manifest-json or something-manifest.json