### PR TITLE
feat: add additional test for handlePassswordValidation

### DIFF
--- a/test/unit/node/util.test.ts
+++ b/test/unit/node/util.test.ts
@@ -349,6 +349,22 @@ describe("isCookieValid", () => {
     })
     expect(isValid).toBe(false)
   })
+  it("should return false and empty string as hashedPassword when passwordMethod is invalid", async () => {
+    const p = "password1"
+    const passwordValidation = await util.handlePasswordValidation({
+      // @ts-expect-error although this shouldn't ever happen, it ensures the default case in this function
+      // works as expected.
+      passwordMethod: "INVALID",
+      passwordFromRequestBody: p,
+      passwordFromArgs: undefined,
+      hashedPasswordFromArgs: undefined,
+    })
+
+    const matchesHash = await util.isHashMatch(p, passwordValidation.hashedPassword)
+
+    expect(passwordValidation.isPasswordValid).toBe(false)
+    expect(matchesHash).toBe(false)
+  })
 })
 
 describe("sanitizeString", () => {


### PR DESCRIPTION
<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

This adds an additional test for `handlePassowrdValidation` to ensure the correct behavior happens when passing in an invalid `passwordMethod`. Although it shouldn't happen, the new test ensurs that `default` case in the switch statement has coverage.

Related to #5153
