### PR TITLE
feat: add test for open

### DIFF
--- a/test/unit/node/util.test.ts
+++ b/test/unit/node/util.test.ts
@@ -537,3 +537,10 @@ describe("isWsl", () => {
     })
   })
 })
+
+describe("open", () => {
+  it("should throw an error if address is a string", async () => {
+    const address = "localhost:3000"
+    await expect(util.open(address)).rejects.toThrow("Cannot open socket paths")
+  })
+})


### PR DESCRIPTION
This PR adds a test  for `open`.

Related to https://github.com/coder/code-server/issues/5153