### PR TITLE
chore: update bug report template description

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -67,7 +67,7 @@ body:
   - type: checkboxes
     attributes:
       label: Does this issue happen in VS Code or GitHub Codespaces?
-      description: Please try reproducing this issue in VS Code
+      description: Please try reproducing this issue in VS Code or GitHub Codespaces
       options:
         - label: I cannot reproduce this in VS Code.
           required: true


### PR DESCRIPTION
I forgot to update the `description` too.

Fixes N/A
