### PR TITLE
chore: only download .deb in docker release

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: "coder/code-server"
           tag: v${{ steps.version.outputs.version }}
-          fileName: "*"
+          fileName: "*.deb"
           out-file-path: "release-packages"
 
       - name: Publish to Docker

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -47,7 +47,7 @@ jobs:
         run: echo "::set-output name=version::$(jq -r .version package.json)"
 
       - name: Download release artifacts
-        uses: robinraju/release-downloader@v1.3
+        uses: robinraju/release-downloader@v1.4
         with:
           repository: "coder/code-server"
           tag: v${{ steps.version.outputs.version }}


### PR DESCRIPTION
Thanks to @ricklambrechts `release-downloader` now supports wildcards for `fileName`. 

https://github.com/robinraju/release-downloader/issues/422