### PR TITLE
fix an integration test error

### DIFF
--- a/test/integration/listExtensions.test.ts
+++ b/test/integration/listExtensions.test.ts
@@ -21,7 +21,7 @@ describe("--list-extensions", () => {
     const pathToUnpackedExtension = path.join(tempDir, `${extName}-${extVersion}`)
     const tempPathToUnpackedExtension = path.join(tempDir, `${extName}-temp`)
     await extract(extensionFixture, { dir: tempPathToUnpackedExtension })
-    await rename(path.join(tempPathToUnpackedExtension, "extension", pathToUnpackedExtension))
+    await rename(path.join(tempPathToUnpackedExtension, "extension"), pathToUnpackedExtension)
   })
   it("should list installed extensions", async () => {
     const { stdout } = await runCodeServerCommand([...setupFlags, "--list-extensions"])


### PR DESCRIPTION
Signed-off-by: lifubang <lifubang@acmcoder.com>
```bash
acmcoder@acmcoder:~/dev/code-server$ # **Before this patch**
acmcoder@acmcoder:~/dev/code-server$ yarn test:integration
yarn run v1.22.19
$ ./ci/dev/test-integration.sh
Set CODE_SERVER_PATH to test another build of code-server
Running tests with code-server binary: 'release-standalone/bin/code-server'
 FAIL  test/integration/listExtensions.test.ts
  ● Test suite failed to run

    test/integration/listExtensions.test.ts:24:11 - error TS2554: Expected 2 arguments, but got 1.

    24     await rename(path.join(tempPathToUnpackedExtension, "extension", pathToUnpackedExtension))
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

      node_modules/@types/node/fs/promises.d.ts:243:40
        243     function rename(oldPath: PathLike, newPath: PathLike): Promise<void>;
                                                   ~~~~~~~~~~~~~~~~~
        An argument for 'newPath' was not provided.

 PASS  test/integration/installExtension.test.ts (13.392 s)

Test Suites: 1 failed, 1 passed, 2 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        14.205 s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
```bash
acmcoder@acmcoder:~/dev/code-server$ # **After the patch**
acmcoder@acmcoder:~/dev/code-server$ yarn test:integration
yarn run v1.22.19
$ ./ci/dev/test-integration.sh
Set CODE_SERVER_PATH to test another build of code-server
Running tests with code-server binary: 'release-standalone/bin/code-server'
 PASS  test/integration/listExtensions.test.ts (9.092 s)
 PASS  test/integration/installExtension.test.ts (11.598 s)

Test Suites: 2 passed, 2 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        12.406 s, estimated 14 s
Ran all test suites.
Done in 21.02s.
```