### PR TITLE
Update display-language.diff

### DIFF
--- a/patches/display-language.diff
+++ b/patches/display-language.diff
@@ -91,7 +91,7 @@ Index: code-server/lib/vscode/src/vs/code/browser/workbench/workbench.html
 +						return cb(undefined, result)
 +					}
 +					const path = nlsConfig['vs/nls']._resolvedLanguagePackCoreLocation + "/" + bundle.replace(/\//g, "!") + ".nls.json"
-+					fetch(`{{WORKBENCH_WEB_BASE_URL}}/vscode-remote-resource?path=${encodeURIComponent(path)}`)
++					fetch(`{{WORKBENCH_WEB_BASE_URL}}/../vscode-remote-resource?path=${encodeURIComponent(path)}`)
 +						.then((response) => response.json())
 +						.then((json) => {
 +							bundles[bundle] = json


### PR DESCRIPTION
The requested "vscode-remote-resource" is not under the "{{WORKBENCH_WEB_BASE_URL}}" path, It needs to access the upper level path.

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes #
