### PR TITLE
fix(terminal): use window.location to work when served NOT on root path

### DIFF
--- a/patches/base-path.diff
+++ b/patches/base-path.diff
@@ -86,6 +86,15 @@ Index: code-server/lib/vscode/src/vs/code/browser/workbench/workbench.html
  		<link data-name="vs/workbench/workbench.web.main" rel="stylesheet" href="{{WORKBENCH_WEB_BASE_URL}}/out/vs/workbench/workbench.web.main.css">
  
  	</head>
+@@ -38,7 +38,7 @@
+ 	<script src="{{WORKBENCH_WEB_BASE_URL}}/out/vs/loader.js"></script>
+ 	<script src="{{WORKBENCH_WEB_BASE_URL}}/out/vs/webPackagePaths.js"></script>
+ 	<script>
+-		const baseUrl = new URL('{{WORKBENCH_WEB_BASE_URL}}', window.location.origin).toString();
++		const baseUrl = new URL('{{WORKBENCH_WEB_BASE_URL}}', window.location).toString();
+ 		Object.keys(self.webPackagePaths).map(function (key, index) {
+ 			self.webPackagePaths[key] = `${baseUrl}/node_modules/${key}/${self.webPackagePaths[key]}`;
+ 		});
 Index: code-server/lib/vscode/src/vs/platform/remote/browser/browserSocketFactory.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/platform/remote/browser/browserSocketFactory.ts


### PR DESCRIPTION
## Description

We made a change in `workbench-dev.html` but forgot to make it in `workbench.html`. This fixes the Integrated Terminal to work when code-server is served NOT on the root path (i.e. accessed at `/vscode` instead of `/`).

Fixes https://github.com/coder/code-server/issues/5321
