### PR TITLE
feat: add message to brew publish

### DIFF
--- a/ci/steps/brew-bump.sh
+++ b/ci/steps/brew-bump.sh
@@ -23,7 +23,7 @@ main() {
   # Find the docs for bump-formula-pr here
   # https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/bump-formula-pr.rb#L18
   local output
-  if ! output=$(brew bump-formula-pr --version="${VERSION}" code-server --no-browse --no-audit 2>&1); then
+  if ! output=$(brew bump-formula-pr --version="${VERSION}" code-server --no-browse --no-audit --message="PR opened by @${GITHUB_ACTOR}" 2>&1); then
     if [[ $output == *"Duplicate PRs should not be opened"* ]]; then
       echo "$VERSION is already submitted"
       exit 0


### PR DESCRIPTION
This uses the [`--message` flag](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/bump-formula-pr.rb#L66-L67) when bumping the homebrew formula so we know who opened the PR and the homebrew team can @ them if any issues arise. 

Fixes N/A
