### PR TITLE
fix: output lost after hotswapping

### DIFF
--- a/src/node/wrapper.ts
+++ b/src/node/wrapper.ts
@@ -292,14 +292,18 @@ export class ParentProcess extends Process {
     const child = this.spawn()
     this.child = child
 
-    // Log both to stdout and to the log directory.
+    // Log child output to stdout/stderr and to the log directory.
     if (child.stdout) {
-      child.stdout.pipe(this.logStdoutStream)
-      child.stdout.pipe(process.stdout)
+      child.stdout.on("data", (data) => {
+        this.logStdoutStream.write(data)
+        process.stdout.write(data)
+      })
     }
     if (child.stderr) {
-      child.stderr.pipe(this.logStderrStream)
-      child.stderr.pipe(process.stderr)
+      child.stderr.on("data", (data) => {
+        this.logStderrStream.write(data)
+        process.stderr.write(data)
+      })
     }
 
     this.logger.debug(`spawned inner process ${child.pid}`)


### PR DESCRIPTION
I think the pipe was closing the other streams when the child stream
closed so instead just write it one way.

This was making it quite difficult to debug code-server when doing live
edits in Coder.