### PR TITLE
chore(prettier): ignore lib/vscode

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+lib/vscode

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -4,14 +4,3 @@ trailingComma: all
 arrowParens: always
 singleQuote: false
 useTabs: false
-
-overrides:
-  # Attempt to keep VScode's existing code style intact.
-  - files: "lib/vscode/**/*.ts"
-    options:
-      # No limit defined upstream.
-      printWidth: 10000
-      semi: true
-      singleQuote: true
-      useTabs: true
-      arrowParens: avoid


### PR DESCRIPTION
We were using an overrides command in our `.prettierrc.yaml` which
quickly became out of sync with Code's Prettier styles.

Instead, we simply tell Prettier to ignore `lib/vscode`.

This way, if you have `formatOnSave` on and you save inside
`lib/vscode`, you won't convert the file to use code-server's styles.

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes #
