### PR TITLE
fix: remove default memory limit

### DIFF
--- a/src/node/wrapper.ts
+++ b/src/node/wrapper.ts
@@ -322,7 +322,6 @@ export class ParentProcess extends Process {
       env: {
         ...process.env,
         CODE_SERVER_PARENT_PID: process.pid.toString(),
-        NODE_OPTIONS: `--max-old-space-size=2048 ${process.env.NODE_OPTIONS || ""}`,
       },
       stdio: ["pipe", "pipe", "pipe", "ipc"],
     })


### PR DESCRIPTION
Having NODE_OPTIONS set is unexpected and although the later flag should
override the previous flag it is not certain that will always be the
case.

Also some users are having issues with the 2 GB limit.