### PR TITLE
feat: Add lifecycle hook

### DIFF
--- a/ci/helm-chart/templates/deployment.yaml
+++ b/ci/helm-chart/templates/deployment.yaml
@@ -62,6 +62,17 @@ spec:
           securityContext:
             runAsUser: {{ .Values.securityContext.runAsUser }}
           {{- end }}
+          {{- if .Values.lifecycle.enabled }}
+          lifecycle:
+            {{- if .Values.lifecycle.postStart }}
+            postStart:
+              {{ toYaml .Values.lifecycle.postStart | nindent 14 }}
+            {{- end }}
+            {{- if .Values.lifecycle.preStop }}
+            preStop:
+              {{ toYaml .Values.lifecycle.preStop | nindent 14 }}
+            {{- end }}
+          {{- end }}
           env:
         {{- if .Values.extraVars }}
 {{ toYaml .Values.extraVars | indent 10 }}

--- a/ci/helm-chart/values.yaml
+++ b/ci/helm-chart/values.yaml
@@ -127,6 +127,15 @@ persistence:
   # existingClaim: ""
   # hostPath: /data
 
+lifecycle:
+  enabled: false
+  # postStart:
+  #  exec:
+  #    command:
+  #      - /bin/bash
+  #      - -c
+  #      - curl -s -L SOME_SCRIPT | bash
+
 ## Enable an Specify container in extraContainers.
 ## This is meant to allow adding code-server dependencies, like docker-dind.
 extraContainers: |


### PR DESCRIPTION
Add container lifecycle hook to helm chart of code-server deployment

It was tested in my self-hosted k8s cluster:

1. Write `custom-values.yaml` for helm deploy
    ```yaml
    # custom-values.yaml
    replicaCount: 1
    service:
      type: ClusterIP
      port: 8080
    lifecycle:
      enabled: true
      postStart:
        exec:
          command:
            - /bin/bash
            - -c
            - curl -s -L https://<my-script-url> | bash
    ```
2. Deploy helm chart with values
      ```
      helm upgrade --install code-server . -f custom-values.yaml
      ```
3. Check deployed manifest by kubectl
    ```bash
    $ kubectl get deploy code-server -o yaml | grep lifecycle -A7 -B0
    
            lifecycle:
              postStart:
                exec:
                  command:
                  - /bin/bash
                  - -c
                  - curl -s -L https://<my-script-url> | bash
    ```


Related to #5382
