### PR TITLE
Logging improvement: PROXY-DOMAIN may be a subdomain + domain

### DIFF
--- a/src/node/main.ts
+++ b/src/node/main.ts
@@ -153,7 +153,7 @@ export const runCodeServer = async (
 
   if (args["proxy-domain"].length > 0) {
     logger.info(`  - ${plural(args["proxy-domain"].length, "Proxying the following domain")}:`)
-    args["proxy-domain"].forEach((domain) => logger.info(`    - *.${domain}`))
+    args["proxy-domain"].forEach((domain) => logger.info(`    - ${domain}`))
   }
 
   if (args.link) {


### PR DESCRIPTION
This logging is confusing when a user passes a full `<subdomain>.<domain>` as proxy-domain.
As an example if PROXY-DOMAIN = `code.test.com`
Before the logging output was:
```
[2022-08-04T16:15:11.829Z] info    - Proxying the following domain:
[2022-08-04T16:15:11.830Z] info      - *.code.test.com
```
After:
```
[2022-08-04T16:15:11.829Z] info    - Proxying the following domain:
[2022-08-04T16:15:11.830Z] info      - code.test.com
```

This was confusing when attempting to setup code-server on a reverse proxy with a service like [cloudflare tunnels](https://www.cloudflare.com/products/tunnel/).

This is likely not the best fix. If preferred, I can do some additional work here to determine if the string is just a domain, or a subdomain+domain, and switch logging behavior based on that condition, and update the PR accordingly. 
