### PR TITLE
chore(ci): run npm job on pr merge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,9 +198,9 @@ jobs:
     # This environment "npm" requires someone from
     # coder/code-server-reviewers to approve the PR before this job runs.
     environment: npm
-    # Only run if PR comes from base repo
+    # Only run if PR comes from base repo or on merge request
     # Reason: forks cannot access secrets and this will always fail
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo


### PR DESCRIPTION
I noticed the npm job wasn't running on merge actions.

See example: https://github.com/coder/code-server/actions/runs/2715111141

This should fix that. 
Fixes N/A
