### PR TITLE
feat: add test for EXTENSIONS_GALLERY

### DIFF
--- a/test/integration/installExtension.test.ts
+++ b/test/integration/installExtension.test.ts
@@ -22,4 +22,11 @@ describe("--install-extension", () => {
     const statInfo = await stat(pathToExtFolder)
     expect(statInfo.isDirectory()).toBe(true)
   }, 20000)
+  it("should use EXTENSIONS_GALLERY when set", async () => {
+    const extName = `author.extension-1.0.0`
+    const { stderr } = await runCodeServerCommand([...setupFlags, "--install-extension", extName], {
+      EXTENSIONS_GALLERY: "{}",
+    })
+    expect(stderr).toMatch("No extension gallery service configured")
+  })
 })

--- a/test/utils/runCodeServerCommand.ts
+++ b/test/utils/runCodeServerCommand.ts
@@ -6,9 +6,14 @@ import { promisify } from "util"
  *
  * A helper function for integration tests to run code-server commands.
  */
-export async function runCodeServerCommand(argv: string[]): Promise<{ stdout: string; stderr: string }> {
+export async function runCodeServerCommand(
+  argv: string[],
+  env?: NodeJS.ProcessEnv,
+): Promise<{ stdout: string; stderr: string }> {
   const CODE_SERVER_COMMAND = process.env.CODE_SERVER_PATH || path.resolve("../../release-standalone/bin/code-server")
-  const { stdout, stderr } = await promisify(exec)(`${CODE_SERVER_COMMAND} ${argv.join(" ")}`)
+  const { stdout, stderr } = await promisify(exec)(`${CODE_SERVER_COMMAND} ${argv.join(" ")}`, {
+    env: { ...process.env, ...env },
+  })
 
   return { stdout, stderr }
 }


### PR DESCRIPTION
## Description

This refactors our integration test helper to allow you to pass environment variables. I also add a new integration test to ensure `EXTENSIONS_GALLERY` is used when passed in.

### Changes
- refactor: add env arg to runCodeServerCommand
- feat: add EXTENSIONS_GALLERY integration test

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes #5364
