### PR TITLE
feat: add --help integration test

### DIFF
--- a/test/integration/help.test.ts
+++ b/test/integration/help.test.ts
@@ -1,0 +1,13 @@
+import { runCodeServerCommand } from "../utils/runCodeServerCommand"
+
+// NOTE@jsjoeio
+// We have this test to ensure that native modules
+// work as expected. If this is called on the wrong
+// platform, the test will fail.
+describe("--help", () => {
+  it("should list code-server usage", async () => {
+    const expectedOutput = "Usage: code-server [options] [path]"
+    const { stdout } = await runCodeServerCommand(["--help"])
+    expect(stdout).toMatch(expectedOutput)
+  }, 20000)
+})


### PR DESCRIPTION
## Description

Previously, we added the `--install-extension` test to ensure that native modules worked as expected with the binary.

However, that relies on a network connection (see https://github.com/microsoft/vscode/issues/142812#issuecomment-1194155328). Instead, I propose this new integration test which checks the `--help` flag
which fails if used on the wrong platform.
<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes #5369
