### PR TITLE
chore(ci): fix when npm job runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,9 +198,9 @@ jobs:
     # This environment "npm" requires someone from
     # coder/code-server-reviewers to approve the PR before this job runs.
     environment: npm
-    # Only run if PR comes from base repo or on merge request
+    # Only run if PR comes from base repo or event is not a PR
     # Reason: forks cannot access secrets and this will always fail
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event.pull_request.merged == true
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo


### PR DESCRIPTION
## Description

Originally, I thought https://github.com/coder/code-server/pull/5429 would fix the issue of the npm job not running on merges into `main`. However, that didn't work. Turns out the action/workflow we were trying to fix is not a `pull_request` event but instead a `push` event. 

<img width="351" alt="image (1)" src="https://user-images.githubusercontent.com/3806031/183990896-47212fe8-a878-4ee7-a689-e7b33385f520.png">

Therefore, we modified the logic to run on PRs into `main` (logic unchanged in file) and added logic to run on all other events besides `pull_request`. This protects it from running on PRs from forks but also allows it to run on `push` into `main`. We went with this approach instead of explicitly writing `main` in the logic so that it doesn't break if we change the default branch name.

### Sources

- https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#available-events
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push
- https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

Fixes N/A
