### PR TITLE
docs: add proxying to angular app

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -386,6 +386,7 @@ Read more about `publicPath` in the [Vue.js docs](https://cli.vuejs.org/config/#
 ### Proxying to an Angular app
 
 In order to use code-server's built-in proxy with Angular, you need to make the following changes in your app:
+
 1. use `<base href="./.">` in `src/index.html`
 2. add `--serve-path /absproxy/4200` to `ng serve` in your `package.json`
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -16,6 +16,7 @@
   - [Stripping `/proxy/<port>` from the request path](#stripping-proxyport-from-the-request-path)
   - [Proxying to create a React app](#proxying-to-create-a-react-app)
   - [Proxying to a Vue app](#proxying-to-a-vue-app)
+  - [Proxying to an Angular app](#proxying-to-an-angular-app)
 - [SSH into code-server on VS Code](#ssh-into-code-server-on-vs-code)
   - [Option 1: cloudflared tunnel](#option-1-cloudflared-tunnel)
   - [Option 2: ngrok tunnel](#option-2-ngrok-tunnel)
@@ -381,6 +382,14 @@ module.exports = {
 3. access app at `<code-server-root>/absproxy/3454` e.g. `http://localhost:8080/absproxy/3454`
 
 Read more about `publicPath` in the [Vue.js docs](https://cli.vuejs.org/config/#publicpath)
+
+### Proxying to an Angular app
+
+In order to use code-server's built-in proxy with Angular, you need to make the following changes in your app:
+1. use `<base href="./.">` in `src/index.html`
+2. add `--serve-path /absproxy/4200` to `ng serve` in your `package.json`
+
+For additional context, see [this GitHub Discussion](https://github.com/coder/code-server/discussions/5439#discussioncomment-3371983).
 
 ## SSH into code-server on VS Code
 

--- a/test/e2e/extensions.test.ts
+++ b/test/e2e/extensions.test.ts
@@ -1,7 +1,7 @@
-import * as path from "path"
 import { test as base } from "@playwright/test"
-import { describe, test, expect } from "./baseFixture"
+import * as path from "path"
 import { getMaybeProxiedCodeServer } from "../utils/helpers"
+import { describe, test, expect } from "./baseFixture"
 
 function runTestExtensionTests() {
   // This will only work if the test extension is loaded into code-server.


### PR DESCRIPTION
This adds docs on how to proxy to an Angular app
- docs(guide): add proxying to Angular app
- fixup: formatting

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes #
