### PR TITLE
refactor: drop db migration patch

### DIFF
--- a/patches/disable-builtin-ext-update.diff
+++ b/patches/disable-builtin-ext-update.diff
@@ -18,7 +18,7 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/extensions/browser/extens
  			if (!this.local.preRelease && this.gallery.properties.isPreReleaseVersion) {
  				return false;
  			}
-@@ -1122,6 +1126,10 @@ export class ExtensionsWorkbenchService
+@@ -1122,6 +1126,10 @@ export class ExtensionsWorkbenchService 
  				// Skip if check updates only for builtin extensions and current extension is not builtin.
  				continue;
  			}

--- a/patches/heartbeat.diff
+++ b/patches/heartbeat.diff
@@ -15,7 +15,7 @@ Index: code-server/lib/vscode/src/vs/base/parts/ipc/common/ipc.net.ts
  
  export const enum SocketDiagnosticsEventType {
  	Created = 'created',
-@@ -828,6 +829,19 @@ export class PersistentProtocol implemen
+@@ -829,6 +830,19 @@ export class PersistentProtocol implemen
  		this._socketDisposables.push(this._socketWriter);
  		this._socketReader = new ProtocolReader(this._socket);
  		this._socketDisposables.push(this._socketReader);

--- a/patches/telemetry.diff
+++ b/patches/telemetry.diff
@@ -104,6 +104,13 @@ Index: code-server/lib/vscode/src/vs/workbench/services/telemetry/browser/teleme
 -				sendErrorTelemetry: this.sendErrorTelemetry,
 -			};
 -			this.impl = this._register(new BaseTelemetryService(config, configurationService, productService));
+-
+-			if (getTelemetryLevel(configurationService) !== TelemetryLevel.NONE) {
+-				// If we cannot fetch the endpoint it means it is down and we should not send any telemetry.
+-				// This is most likely due to ad blockers
+-				fetch(telemetryEndpointUrl, { method: 'POST' }).catch(err => {
+-					this.impl = NullTelemetryService;
+-				});
 +			const telemetryProvider: ITelemetryAppender | undefined = remoteAgentService.getConnection() !== null ? { log: remoteAgentService.logTelemetry.bind(remoteAgentService), flush: remoteAgentService.flushTelemetry.bind(remoteAgentService) } : productService.aiConfig?.ariaKey ? new OneDataSystemWebAppender(isInternal, 'monacoworkbench', null, productService.aiConfig?.ariaKey) : undefined;
 +			if (telemetryProvider) {
 +				appenders.push(telemetryProvider);
@@ -114,13 +121,7 @@ Index: code-server/lib/vscode/src/vs/workbench/services/telemetry/browser/teleme
 +					sendErrorTelemetry: this.sendErrorTelemetry,
 +				};
 +				this.impl = this._register(new BaseTelemetryService(config, configurationService, productService));
- 
--			if (getTelemetryLevel(configurationService) !== TelemetryLevel.NONE) {
--				// If we cannot fetch the endpoint it means it is down and we should not send any telemetry.
--				// This is most likely due to ad blockers
--				fetch(telemetryEndpointUrl, { method: 'POST' }).catch(err => {
--					this.impl = NullTelemetryService;
--				});
++
 +				if (remoteAgentService.getConnection() === null && getTelemetryLevel(configurationService) !== TelemetryLevel.NONE) {
 +					// If we cannot fetch the endpoint it means it is down and we should not send any telemetry.
 +					// This is most likely due to ad blockers

--- a/patches/unique-db.diff
+++ b/patches/unique-db.diff
@@ -9,11 +9,6 @@ ensures that different browser paths will be unique (for example /workspace1 and
 The easiest way to test is to open files in the same workspace using both / and
 /vscode and make sure they are not interacting with each other.
 
-It should also migrate old databases which can be tested by opening in an old
-code-server.
-
-This has e2e tests.
-
 Index: code-server/lib/vscode/src/vs/workbench/services/storage/browser/storageService.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/services/storage/browser/storageService.ts
@@ -37,31 +32,5 @@ Index: code-server/lib/vscode/src/vs/workbench/services/storage/browser/storageS
 +				// scoped to a path) as long as they are hosted on different paths.
 +				return this.payload.id + '-' + hash(location.pathname.toString().replace(/\/$/, "")).toString(16);
  		}
- 	}
- 
-@@ -141,6 +146,25 @@ export class BrowserStorageService exten
- 
- 		await this.workspaceStorage.init();
- 
-+		const firstWorkspaceOpen = this.workspaceStorage.getBoolean(IS_NEW_KEY);
-+		if (firstWorkspaceOpen === undefined) {
-+			// Migrate the old database.
-+			let db: IIndexedDBStorageDatabase | undefined
-+			try {
-+				db = await IndexedDBStorageDatabase.create({ id: this.payload.id }, this.logService)
-+				const items = await db.getItems()
-+				for (const [key, value] of items) {
-+					this.workspaceStorage.set(key, value);
-+				}
-+			} catch (error) {
-+				this.logService.error(`[IndexedDB Storage ${this.payload.id}] migrate error: ${toErrorMessage(error)}`);
-+			} finally {
-+				if (db) {
-+					db.close()
-+				}
-+			}
-+		}
-+
- 		this.updateIsNew(this.workspaceStorage);
  	}
  

--- a/test/e2e/codeServer.test.ts
+++ b/test/e2e/codeServer.test.ts
@@ -1,8 +1,5 @@
-import * as cp from "child_process"
 import { promises as fs } from "fs"
-import * as os from "os"
 import * as path from "path"
-import * as util from "util"
 import { getMaybeProxiedCodeServer } from "../utils/helpers"
 import { describe, test, expect } from "./baseFixture"
 import { CodeServer } from "./models/CodeServer"
@@ -16,30 +13,6 @@ describe("code-server", [], {}, () => {
     instances.clear()
     await Promise.all(procs.map((cs) => cs.close()))
   })
-
-  /**
-   * Spawn a specific version of code-server using the install script.
-   */
-  const spawn = async (version: string, dir?: string): Promise<CodeServer> => {
-    let instance = instances.get(version)
-    if (!instance) {
-      await util.promisify(cp.exec)(`./install.sh --method standalone --version ${version}`, {
-        cwd: path.join(__dirname, "../.."),
-      })
-
-      instance = new CodeServer(
-        "code-server@" + version,
-        ["--auth=none"],
-        { VSCODE_DEV: "" },
-        dir,
-        `${os.homedir()}/.local/lib/code-server-${version}`,
-      )
-
-      instances.set(version, instance)
-    }
-
-    return instance
-  }
 
   test("should navigate to home page", async ({ codeServerPage }) => {
     // We navigate codeServer before each test
@@ -67,55 +40,5 @@ describe("code-server", [], {}, () => {
     const file = path.join(dir, "foo")
     await fs.writeFile(file, "bar")
     await codeServerPage.openFile(file)
-  })
-
-  test("should migrate state to avoid collisions", async ({ codeServerPage }) => {
-    // This can take a very long time in development because of how long pages
-    // take to load and we are doing a lot of that here.
-    if (process.env.VSCODE_DEV === "1") {
-      test.slow()
-    }
-
-    const dir = await codeServerPage.workspaceDir
-    const files = [path.join(dir, "foo"), path.join(dir, "bar")]
-    await Promise.all(
-      files.map((file) => {
-        return fs.writeFile(file, path.basename(file))
-      }),
-    )
-
-    // Open a file in the latest instance.
-    await codeServerPage.openFile(files[0])
-    await codeServerPage.stateFlush()
-
-    // Open a file in an older version of code-server.  It should not see the
-    // file opened in the new instance since the database has a different
-    // name.  This must be accessed through the proxy so it shares the same
-    // domain and can write to the same database.
-    const cs = await spawn("4.0.2", dir)
-    const address = new URL(await cs.address())
-
-    await codeServerPage.navigate("/proxy/" + address.port + "/")
-    await codeServerPage.openFile(files[1])
-    expect(await codeServerPage.tabIsVisible(files[0])).toBe(false)
-    await codeServerPage.stateFlush()
-
-    // Move back to latest code-server.  We should see the file we previously
-    // opened with it but not the old code-server file because the new instance
-    // already created its own database on this path and will avoid migrating.
-    await codeServerPage.navigate()
-    await codeServerPage.waitForTab(files[0])
-    expect(await codeServerPage.tabIsVisible(files[1])).toBe(false)
-
-    // Open a new path in latest code-server.  This one should migrate the
-    // database from old code-server but see nothing from the new database
-    // created on the root.
-    await codeServerPage.navigate("/vscode")
-    await codeServerPage.waitForTab(files[1])
-    expect(await codeServerPage.tabIsVisible(files[0])).toBe(false)
-    // Should still be open after a reload.
-    await codeServerPage.navigate("/vscode")
-    await codeServerPage.waitForTab(files[1])
-    expect(await codeServerPage.tabIsVisible(files[0])).toBe(false)
   })
 })


### PR DESCRIPTION
This drops the patch and also the tests (which were flakey and our longest running e2e tests).

- refactor: remove database migration patch & test
- chore: refresh patches

Fixes https://github.com/coder/code-server/issues/5482