### PR TITLE
chore: add npm followup comment

### DIFF
--- a/ci/build/npm-postinstall.sh
+++ b/ci/build/npm-postinstall.sh
@@ -140,6 +140,9 @@ install_with_yarn_or_npm() {
         echo "yarn.lock file present, running in development mode. use yarn to install code-server!"
         exit 1
       else
+        # HACK: NPM's use of semver doesn't like resolving some peerDependencies that vscode (upstream) brings in the form of pre-releases.
+        # The legacy behavior doesn't complain about pre-releases being used, falling back to that for now.
+        # See https://github.com//pull/5071
         npm install --unsafe-perm --legacy-peer-deps --omit=dev
       fi
       ;;


### PR DESCRIPTION
- chore: use npm ci in build-standalone-release
- docs: add comment to npm-postinstall.sh

followup from https://github.com/coder/code-server/pull/5533