### PR TITLE
Fix deb install instructions: ${VERSION}_foo

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -154,8 +154,8 @@ code-server
 > upgrade or [build with npm](#npm).
 
 ```bash
-curl -fOL https://github.com/coder/code-server/releases/download/v$VERSION/code-server_$VERSION_amd64.deb
-sudo dpkg -i code-server_$VERSION_amd64.deb
+curl -fOL https://github.com/coder/code-server/releases/download/v$VERSION/code-server_${VERSION}_amd64.deb
+sudo dpkg -i code-server_${VERSION}_amd64.deb
 sudo systemctl enable --now code-server@$USER
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```


### PR DESCRIPTION
The install instructions weren't copy-pastable: `$VERSION_foo` is the same as `${VERSION_foo}`, not `${VERSION}_foo`.

```sh
$ VERSION=4.6.1
$ curl -fOL https://github.com/coder/code-server/releases/download/v$VERSION/code-server_$VERSION_amd64.deb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     9    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
$ echo curl -fOL https://github.com/coder/code-server/releases/download/v$VERSION/code-server_$VERSION_amd64.deb
curl -fOL https://github.com/coder/code-server/releases/download/v4.6.1/code-server_.deb
```

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes #
