### PR TITLE
fix(ci): specify ref in aur publish job

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -95,6 +95,7 @@ jobs:
         with:
           repository: "cdrci/code-server-aur"
           token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          ref: "master"
 
       - name: Configure git
         run: |


### PR DESCRIPTION
I've noticed the last two times the `aur` job runs and opens a PR into `code-server-aur`, there are conflicts. It seems like it's not getting the latest commits. Based on [this](https://github.com/actions/checkout/issues/439#issuecomment-830862188), I think specifying `ref` may help.

I do not see any downsides to adding this even if this doesn't fix it.