### PR TITLE
chore: update Code to 1.71.1

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -111,6 +111,15 @@ re-apply the patches.
 6. Commit the updated submodule and patches to `code-server`.
 7. Open a PR.
 
+Tip: if you're certain all patches are applied correctly and you simply need to
+refresh, you can use this trick:
+
+```shell
+while quilt push; do quilt refresh; done
+```
+
+[Source](https://raphaelhertzog.com/2012/08/08/how-to-use-quilt-to-manage-patches-in-debian-packages/)
+
 ### Patching Code
 
 0. You can go through the patch stack with `quilt push` and `quilt pop`.

--- a/patches/disable-builtin-ext-update.diff
+++ b/patches/disable-builtin-ext-update.diff
@@ -18,7 +18,7 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/extensions/browser/extens
  			if (!this.local.preRelease && this.gallery.properties.isPreReleaseVersion) {
  				return false;
  			}
-@@ -1121,6 +1125,10 @@ export class ExtensionsWorkbenchService
+@@ -1121,6 +1125,10 @@ export class ExtensionsWorkbenchService 
  				// Skip if check updates only for builtin extensions and current extension is not builtin.
  				continue;
  			}

--- a/patches/logout.diff
+++ b/patches/logout.diff
@@ -68,7 +68,7 @@ Index: code-server/lib/vscode/src/vs/workbench/browser/client.ts
  	constructor (
  		@ILogService private logService: ILogService,
  		@INotificationService private notificationService: INotificationService,
-@@ -82,6 +86,10 @@ export class CodeServerClient extends Di
+@@ -81,6 +85,10 @@ export class CodeServerClient extends Di
  		if (this.productService.updateEndpoint) {
  			this.checkUpdates(this.productService.updateEndpoint)
  		}
@@ -79,7 +79,7 @@ Index: code-server/lib/vscode/src/vs/workbench/browser/client.ts
  	}
  
  	private checkUpdates(updateEndpoint: string) {
-@@ -133,4 +141,25 @@ export class CodeServerClient extends Di
+@@ -132,4 +140,25 @@ export class CodeServerClient extends Di
  
  		updateLoop();
  	}

--- a/patches/service-worker.diff
+++ b/patches/service-worker.diff
@@ -36,7 +36,7 @@ Index: code-server/lib/vscode/src/vs/workbench/browser/client.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/browser/client.ts
 +++ code-server/lib/vscode/src/vs/workbench/browser/client.ts
-@@ -90,6 +90,10 @@ export class CodeServerClient extends Di
+@@ -89,6 +89,10 @@ export class CodeServerClient extends Di
  		if (this.productService.logoutEndpoint) {
  			this.addLogoutCommand(this.productService.logoutEndpoint);
  		}
@@ -47,7 +47,7 @@ Index: code-server/lib/vscode/src/vs/workbench/browser/client.ts
  	}
  
  	private checkUpdates(updateEndpoint: string) {
-@@ -162,4 +166,17 @@ export class CodeServerClient extends Di
+@@ -161,4 +165,17 @@ export class CodeServerClient extends Di
  			});
  		}
  	}

--- a/patches/update-check.diff
+++ b/patches/update-check.diff
@@ -29,7 +29,7 @@ Index: code-server/lib/vscode/src/vs/workbench/browser/client.ts
  	) {
  		super();
  	}
-@@ -72,5 +78,59 @@ export class CodeServerClient extends Di
+@@ -71,5 +77,59 @@ export class CodeServerClient extends Di
  				},
  			});
  		}


### PR DESCRIPTION
This updates Code to 1.71 and makes a small doc change.

## Changes
- chore: update Code to 1.71.1
- chore: refresh patches
- docs: add quilt refresh tip

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes #5554
