### PR TITLE
Set RPM Upgrade Flag

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -364,7 +364,7 @@ install_rpm() {
 
   fetch "https://github.com/coder/code-server/releases/download/v$VERSION/code-server-$VERSION-$ARCH.rpm" \
     "$CACHE_DIR/code-server-$VERSION-$ARCH.rpm"
-  sudo_sh_c rpm -i "$CACHE_DIR/code-server-$VERSION-$ARCH.rpm"
+  sudo_sh_c rpm -U "$CACHE_DIR/code-server-$VERSION-$ARCH.rpm"
 
   echo_systemd_postinstall rpm
 }


### PR DESCRIPTION
Fixes #5383, RPM installs should use the -U flag instead of -i because -U will upgrade instead of failing if code-server is already installed.
