### PR TITLE
fix: fix can't run it as expected in freebsd

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -556,7 +556,7 @@ sudo_sh_c() {
   elif command_exists sudo; then
     sh_c "sudo $*"
   elif command_exists su; then
-    sh_c "su - -c '$*'"
+    sh_c "su root -c '$*'"
   else
     echoh
     echoerr "This script needs to run the following command as root."


### PR DESCRIPTION
In freebsd, su -c expects a login class argument instead of a command, if -c is preceded by a username, then -c and the arguments that follow will be passed as shell arguments

Fixes #5594
