### PR TITLE
fix potential typo for "installing with npm"

### DIFF
--- a/docs/termux.md
+++ b/docs/termux.md
@@ -100,7 +100,7 @@ node -v
 
 you will get node version `v16.15.0`
 
-5. Now install code-server following our guide on [installing with npm][./npm.md](./npm.md)
+5. Now install code-server following our guide on [installing with npm](./npm.md)
 
 6. Congratulation code-server is installed on your device using the following command.
 


### PR DESCRIPTION
the link for installing with NPM on line 103 was written as

[installing with npm][./npm.md](./npm.md) `[installing with npm][./npm.md](./npm.md)` 
I fixed it to look like
[installing with npm](./npm.md) `[installing with npm](./npm.md)`


