### PR TITLE
add CLI argument `--disable-workspace-trust`

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -50,6 +50,7 @@ export interface UserProvidedCodeArgs {
   "github-auth"?: string
   "disable-update-check"?: boolean
   "disable-file-downloads"?: boolean
+  "disable-workspace-trust"?: boolean
 }
 
 /**
@@ -162,6 +163,10 @@ export const options: Options<Required<UserProvidedArgs>> = {
     type: "boolean",
     description:
       "Disable file downloads from Code. This can also be set with CS_DISABLE_FILE_DOWNLOADS set to 'true' or '1'.",
+  },
+  "disable-workspace-trust": {
+    type: "boolean",
+    description: "Disable Workspace Trust feature. This switch only affects the current session.",
   },
   // --enable can be used to enable experimental features. These features
   // provide no guarantees.

--- a/test/e2e/codeServer.test.ts
+++ b/test/e2e/codeServer.test.ts
@@ -4,7 +4,7 @@ import { getMaybeProxiedCodeServer } from "../utils/helpers"
 import { describe, test, expect } from "./baseFixture"
 import { CodeServer } from "./models/CodeServer"
 
-describe("code-server", [], {}, () => {
+describe("code-server", ["--disable-workspace-trust"], {}, () => {
   // TODO@asher: Generalize this?  Could be nice if we were to ever need
   // multiple migration tests in other suites.
   const instances = new Map<string, CodeServer>()

--- a/test/e2e/displayLang.test.ts
+++ b/test/e2e/displayLang.test.ts
@@ -3,12 +3,17 @@ import { describe, test, expect } from "./baseFixture"
 
 // Given a code-server environment with Spanish Language Pack extension installed
 // and a languagepacks.json in the data-dir
-describe("--locale es", ["--extensions-dir", path.join(__dirname, "./extensions"), "--locale", "es"], {}, () => {
-  test("should load code-server in Spanish", async ({ codeServerPage }) => {
-    // When
-    const visible = await codeServerPage.page.isVisible("text=Explorador")
+describe(
+  "--locale es",
+  ["--disable-workspace-trust", "--extensions-dir", path.join(__dirname, "./extensions"), "--locale", "es"],
+  {},
+  () => {
+    test("should load code-server in Spanish", async ({ codeServerPage }) => {
+      // When
+      const visible = await codeServerPage.page.isVisible("text=Explorador")
 
-    // Then
-    expect(visible).toBe(true)
-  })
-})
+      // Then
+      expect(visible).toBe(true)
+    })
+  },
+)

--- a/test/e2e/downloads.test.ts
+++ b/test/e2e/downloads.test.ts
@@ -3,7 +3,7 @@ import * as path from "path"
 import { clean } from "../utils/helpers"
 import { describe, test, expect } from "./baseFixture"
 
-describe("Downloads (enabled)", [], {}, async () => {
+describe("Downloads (enabled)", ["--disable-workspace-trust"], {}, async () => {
   const testName = "downloads-enabled"
   test.beforeAll(async () => {
     await clean(testName)
@@ -25,7 +25,7 @@ describe("Downloads (enabled)", [], {}, async () => {
   })
 })
 
-describe("Downloads (disabled)", ["--disable-file-downloads"], {}, async () => {
+describe("Downloads (disabled)", ["--disable-workspace-trust", "--disable-file-downloads"], {}, async () => {
   const testName = "downloads-disabled"
   test.beforeAll(async () => {
     await clean(testName)

--- a/test/e2e/extensions.test.ts
+++ b/test/e2e/extensions.test.ts
@@ -19,7 +19,7 @@ function runTestExtensionTests() {
   })
 }
 
-const flags = ["--extensions-dir", path.join(__dirname, "./extensions")]
+const flags = ["--disable-workspace-trust", "--extensions-dir", path.join(__dirname, "./extensions")]
 
 describe("Extensions", flags, {}, () => {
   runTestExtensionTests()

--- a/test/e2e/github.test.ts
+++ b/test/e2e/github.test.ts
@@ -2,7 +2,7 @@ import { test as base } from "@playwright/test"
 import { describe, expect, test } from "./baseFixture"
 
 if (process.env.GITHUB_TOKEN) {
-  describe("GitHub token", [], {}, () => {
+  describe("GitHub token", ["--disable-workspace-trust"], {}, () => {
     test("should be logged in to pull requests extension", async ({ codeServerPage }) => {
       await codeServerPage.exec("git init")
       await codeServerPage.exec("git remote add origin https://github.com/coder/code-server")
@@ -16,7 +16,7 @@ if (process.env.GITHUB_TOKEN) {
     })
   })
 
-  describe("No GitHub token", [], { GITHUB_TOKEN: "" }, () => {
+  describe("No GitHub token", ["--disable-workspace-trust"], { GITHUB_TOKEN: "" }, () => {
     test("should not be logged in to pull requests extension", async ({ codeServerPage }) => {
       await codeServerPage.exec("git init")
       await codeServerPage.exec("git remote add origin https://github.com/coder/code-server")

--- a/test/e2e/login.test.ts
+++ b/test/e2e/login.test.ts
@@ -1,7 +1,7 @@
 import { PASSWORD } from "../utils/constants"
 import { describe, test, expect } from "./baseFixture"
 
-describe("login", ["--auth", "password"], {}, () => {
+describe("login", ["--disable-workspace-trust", "--auth", "password"], {}, () => {
   test("should see the login page", async ({ codeServerPage }) => {
     // It should send us to the login page
     expect(await codeServerPage.page.title()).toBe("code-server login")

--- a/test/e2e/logout.test.ts
+++ b/test/e2e/logout.test.ts
@@ -1,7 +1,7 @@
 // NOTE@jsjoeio commenting out until we can figure out what's wrong
 // import { describe, test, expect } from "./baseFixture"
 
-// describe("logout", true, [], {}, () => {
+// describe("logout", true, ["--disable-workspace-trust"], {}, () => {
 //   test("should be able logout", async ({ codeServerPage }) => {
 //     // Recommended by Playwright for async navigation
 //     // https://github.com/microsoft/playwright/issues/1987#issuecomment-620182151

--- a/test/e2e/models/CodeServer.ts
+++ b/test/e2e/models/CodeServer.ts
@@ -82,9 +82,6 @@ export class CodeServer {
       path.join(dir, "User/settings.json"),
       JSON.stringify({
         "workbench.startupEditor": "none",
-        // NOTE@jsjoeio - needed to prevent Trust Policy prompt
-        // in end-to-end tests.
-        "security.workspace.trust.enabled": false,
       }),
       "utf8",
     )

--- a/test/e2e/openHelpAbout.test.ts
+++ b/test/e2e/openHelpAbout.test.ts
@@ -1,7 +1,7 @@
 import { version } from "../../src/node/constants"
 import { describe, test, expect } from "./baseFixture"
 
-describe("Open Help > About", [], {}, () => {
+describe("Open Help > About", ["--disable-workspace-trust"], {}, () => {
   test("should see code-server version in about dialog", async ({ codeServerPage }) => {
     // Open using the menu.
     await codeServerPage.navigateMenus(["Help", "About"])

--- a/test/e2e/terminal.test.ts
+++ b/test/e2e/terminal.test.ts
@@ -5,7 +5,7 @@ import util from "util"
 import { clean, getMaybeProxiedCodeServer, tmpdir } from "../utils/helpers"
 import { describe, expect, test } from "./baseFixture"
 
-describe("Integrated Terminal", [], {}, () => {
+describe("Integrated Terminal", ["--disable-workspace-trust"], {}, () => {
   const testName = "integrated-terminal"
   test.beforeAll(async () => {
     await clean(testName)

--- a/test/e2e/trust.test.ts
+++ b/test/e2e/trust.test.ts
@@ -1,0 +1,13 @@
+import { describe, test, expect } from "./baseFixture"
+
+describe("Workspace trust (enabled)", [], {}, async () => {
+  test("should see the 'I Trust...' option", async ({ codeServerPage }) => {
+    expect(await codeServerPage.page.isVisible("text=Yes, I trust")).toBe(true)
+  })
+})
+
+describe("Workspace trust (disabled)", ["--disable-workspace-trust"], {}, async () => {
+  test("should not see the 'I Trust...' option", async ({ codeServerPage }) => {
+    expect(await codeServerPage.page.isVisible("text=Yes, I trust")).toBe(false)
+  })
+})


### PR DESCRIPTION
Add CLI flag to disable workspace trust feature, as described in documentation:
https://code.visualstudio.com/docs/editor/workspace-trust

Fixes #5288 