### PR TITLE
fix: Enable the `BROWSER` environment variable

### DIFF
--- a/src/node/routes/vscode.ts
+++ b/src/node/routes/vscode.ts
@@ -156,9 +156,7 @@ export class CodeServerRouteWrapper {
     try {
       this._codeServerMain = await createVSServer(null, {
         ...(await toCodeArgs(args)),
-        // TODO: Make the browser helper script work.
         "without-connection-token": true,
-        "without-browser-env-var": true,
       })
     } catch (error) {
       logError(logger, "CodeServerRouteWrapper", error)


### PR DESCRIPTION
This was breaking the automatic opening of links in GIT_ASKPASS on a git clone. I've tried to execute this script manually, and it does indeed work!
