### PR TITLE
release: 4.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Code v1.72.1
 
 - Fixed bug in code-server (run with Docker) where PATH was always overwritten
 - Enabled `BROWSER` environment variable
-- Patched `asExternalUri` to work so now extensions run inside code-server can use it
+- Patched `asExternalUri` to work so now extensions running inside code-server can use it
 
 ## [4.7.1](https://github.com/coder/code-server/releases/tag/v4.7.1) - 2022-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,29 @@ Code v99.99.999
 
 -->
 
+## [4.8.0](https://github.com/coder/code-server/releases/tag/v4.8.0) - 2022-10-24
+
+Code v1.72.1
+
+### Added
+
+- Support for the Ports panel which leverages code-server's built-in proxy. It
+  also uses `VSCODE_PROXY_URI` where `{{port}}` is replace when forwarding a port.
+  Example: `VSCODE_PROXY_URI=https://{{port}}.kyle.dev` would forward an
+  application running on localhost:3000 to https://3000.kyle.dev
+- support for `--disable-workspace-trust` CLI flag
+- support for `--goto` flag to open file @ line:column
+
+### Changed
+
+- Updated Code to 1.72.1
+
+### Fixed
+
+- Fixed bug in code-server (run with Docker) where PATH was always overwritten
+- Enalbed `BROWSER` environment variable
+- Patched `asExternalUri` to work so now extensions run inside code-server can use it
+
 ## [4.7.1](https://github.com/coder/code-server/releases/tag/v4.7.1) - 2022-09-30
 
 Code v1.71.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,11 @@ Code v1.72.1
   also uses `VSCODE_PROXY_URI` where `{{port}}` is replace when forwarding a port.
   Example: `VSCODE_PROXY_URI=https://{{port}}.kyle.dev` would forward an
   application running on localhost:3000 to https://3000.kyle.dev
-- support for `--disable-workspace-trust` CLI flag
-- support for `--goto` flag to open file @ line:column
+- Support for `--disable-workspace-trust` CLI flag
+- Support for `--goto` flag to open file @ line:column
+- Added Ubuntu-based images for Docker releases. If you run into issues with
+  `PATH` being overwritten in Docker please try the Ubuntu image as this is a
+  problem in the Debian base image.
 
 ### Changed
 
@@ -39,9 +42,8 @@ Code v1.72.1
 
 ### Fixed
 
-- Fixed bug in code-server (run with Docker) where PATH was always overwritten
 - Enabled `BROWSER` environment variable
-- Patched `asExternalUri` to work so now extensions running inside code-server can use it
+- Patched `asExternalUri` to work so now extensions run inside code-server can use it
 
 ## [4.7.1](https://github.com/coder/code-server/releases/tag/v4.7.1) - 2022-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Code v1.72.1
 ### Fixed
 
 - Fixed bug in code-server (run with Docker) where PATH was always overwritten
-- Enalbed `BROWSER` environment variable
+- Enabled `BROWSER` environment variable
 - Patched `asExternalUri` to work so now extensions run inside code-server can use it
 
 ## [4.7.1](https://github.com/coder/code-server/releases/tag/v4.7.1) - 2022-09-30

--- a/ci/helm-chart/Chart.yaml
+++ b/ci/helm-chart/Chart.yaml
@@ -20,4 +20,4 @@ version: 3.2.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.7.1
+appVersion: 4.8.0

--- a/ci/helm-chart/Chart.yaml
+++ b/ci/helm-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.3
+version: 3.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/ci/helm-chart/values.yaml
+++ b/ci/helm-chart/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: codercom/code-server
-  tag: '4.7.1'
+  tag: '4.8.0'
   pullPolicy: Always
 
 # Specifies one or more secrets to be used when pulling images from a

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -1,6 +1,6 @@
 # code-server Helm Chart
 
-[![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) [![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![AppVersion: 4.7.1](https://img.shields.io/badge/AppVersion-4.7.1-informational?style=flat-square)](https://img.shields.io/badge/AppVersion-4.7.1-informational?style=flat-square)
+[![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) [![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)](https://img.shields.io/badge/Type-application-informational?style=flat-square) [![AppVersion: 4.8.0](https://img.shields.io/badge/AppVersion-4.8.0-informational?style=flat-square)](https://img.shields.io/badge/AppVersion-4.8.0-informational?style=flat-square)
 
 [code-server](https://github.com/coder/code-server) code-server is VS Code running
 on a remote server, accessible through the browser.
@@ -73,7 +73,7 @@ and their default values.
 | hostnameOverride                            | string | `""`                     |
 | image.pullPolicy                            | string | `"Always"`               |
 | image.repository                            | string | `"codercom/code-server"` |
-| image.tag                                   | string | `"4.7.1"`                |
+| image.tag                                   | string | `"4.8.0"`                |
 | imagePullSecrets                            | list   | `[]`                     |
 | ingress.enabled                             | bool   | `false`                  |
 | nameOverride                                | string | `""`                     |

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,5 +1,5 @@
 {
-  "versions": ["v4.7.1"],
+  "versions": ["v4.8.0"],
   "routes": [
     {
       "title": "Home",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-server",
   "license": "MIT",
-  "version": "4.7.1",
+  "version": "4.8.0",
   "description": "Run VS Code on a remote server.",
   "homepage": "https://github.com/coder/code-server",
   "bugs": {

--- a/patches/telemetry.diff
+++ b/patches/telemetry.diff
@@ -3,7 +3,7 @@ Add support for telemetry endpoint
 To test:
 1. Create a RequestBin - https://requestbin.io/
 2. Run code-server with `CS_TELEMETRY_URL` set: 
-  i.e. `CS_TELEMETRY_URL="https://requestbin.io/1ebub9z1" ./code-server-4.7.1-macos-amd64/bin/code-server`
+  i.e. `CS_TELEMETRY_URL="https://requestbin.io/1ebub9z1" ./code-server-4.8.0-macos-amd64/bin/code-server`
 3. Load code-server in browser an do things (i.e. open a file)
 4. Refresh RequestBin and you should see logs
 

--- a/test/unit/node/test-plugin/package.json
+++ b/test/unit/node/test-plugin/package.json
@@ -3,7 +3,7 @@
   "name": "test-plugin",
   "version": "1.0.0",
   "engines": {
-    "code-server": "^4.7.1"
+    "code-server": "^4.8.0"
   },
   "main": "out/index.js",
   "devDependencies": {


### PR DESCRIPTION
<!-- Note: this variable $CODE_SERVER_VERSION_TO_UPDATE will be set when you run the release-prep.sh script with `yarn release:prep` -->

This PR is to generate a new release of `code-server` at `4.8.0`

## Screenshot

<img width="1712" alt="image" src="https://user-images.githubusercontent.com/3806031/197634673-c31f0d4e-7b0e-447e-a4f0-b7b8cebe615b.png">


## TODOs

Follow "Publishing a release" steps in `ci/README.md`

<!-- Note some of these steps below are redundant since they're listed in the "Publishing a release" docs -->

- [x] update `CHANGELOG.md`
- [ ] manually run "Draft release" workflow after merging this PR
- [ ] merge PR opened in [code-server-aur](https://github.com/coder/code-server-aur)