### PR TITLE
fix: pin azure/setup-helm to v3.10.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,6 +85,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: azure/setup-helm@v3.3
         with:
+          version: "v3.10.1"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install helm kubeval plugin


### PR DESCRIPTION
Due to https://github.com/Azure/setup-helm/issues/99, this pins the
version to v3.10.1 as a temporary fix.
