### PR TITLE
release: 4.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ Code v99.99.999
 
 -->
 
+## [4.8.1](https://github.com/coder/code-server/releases/tag/v4.8.1) - 2022-10-28
+
+Code v1.72.1
+
+### Fixed
+
+- Fixed CSP error introduced in 4.8.0 that caused issues with webviews and most
+  extensions.
+
 ## [4.8.0](https://github.com/coder/code-server/releases/tag/v4.8.0) - 2022-10-24
 
 Code v1.72.1

--- a/ci/helm-chart/Chart.yaml
+++ b/ci/helm-chart/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.3.0
+version: 3.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.8.0
+appVersion: 4.8.1

--- a/ci/helm-chart/values.yaml
+++ b/ci/helm-chart/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: codercom/code-server
-  tag: '4.8.0'
+  tag: '4.8.1'
   pullPolicy: Always
 
 # Specifies one or more secrets to be used when pulling images from a

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-server",
   "license": "MIT",
-  "version": "4.8.1-rc.1",
+  "version": "4.8.1",
   "description": "Run VS Code on a remote server.",
   "homepage": "https://github.com/coder/code-server",
   "bugs": {

--- a/test/unit/node/test-plugin/package.json
+++ b/test/unit/node/test-plugin/package.json
@@ -3,7 +3,7 @@
   "name": "test-plugin",
   "version": "1.0.0",
   "engines": {
-    "code-server": "^4.8.1-rc.1"
+    "code-server": "^4.8.1"
   },
   "main": "out/index.js",
   "devDependencies": {


### PR DESCRIPTION
<!-- Note: this variable $CODE_SERVER_VERSION_TO_UPDATE will be set when you run the release-prep.sh script with `yarn release:prep` -->

This PR is to generate a new release of `code-server` at `4.8.1`

## Screenshot

TODO

## TODOs

Follow "Publishing a release" steps in `ci/README.md`

<!-- Note some of these steps below are redundant since they're listed in the "Publishing a release" docs -->

- [x] update `CHANGELOG.md`
- [ ] close homebrew PR for 4.8.0 if not already merged (will lead to errors after publish otherwise)
- [ ] manually run "Draft release" workflow after merging this PR
- [ ] merge PR opened in [code-server-aur](https://github.com/coder/code-server-aur)