### PR TITLE
fix: merge in master from coder/code-server-aur

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -97,6 +97,12 @@ jobs:
           token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           ref: "master"
 
+      - name: Merge in master
+        run: |
+          git remote add upstream https://github.com/coder/code-server-aur.git
+          git fetch upstream
+          git merge upstream/master
+
       - name: Configure git
         run: |
           git config --global user.name cdrci


### PR DESCRIPTION
This ensures that the branch is up-to-date with coder/code-server-aur
before opening a PR.
