### PR TITLE
fix installing code-server on manjaro image

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -387,7 +387,7 @@ install_aur() {
   if [ ! "${DRY_RUN-}" ]; then
     cd "$CACHE_DIR/code-server-aur"
   fi
-  sh_c makepkg -si
+  sh_c makepkg -si --noconfirm
 
   echo_systemd_postinstall AUR
 }


### PR DESCRIPTION
# Description

This patch fixes installation on coder.com on a kubernetes installation. Without the `--noconfirm` the install.sh script warns about that the package has not been installed. With this parameter set the installation succeed.

This is log message which suddly gets truncated

![image](https://user-images.githubusercontent.com/103434584/205486038-32ea2e7e-ce71-4491-a268-587e32a8f3d0.png)

If I download install.sh via wget and run it with:

```
cat install.sh | sh | tee code-server-install.log
```

![image](https://user-images.githubusercontent.com/103434584/205486427-e644b859-0ec2-4f78-af82-990b76db1dff.png)


The warning was caused while there is no confirmation.

# Patch

Steps to confirm patch is working:

- Spawn a manjaro based image up (without install.sh in template)
- wget current version of this script
- append parameter `--noconfirm`
- cat install.sh | sh | tee code-server-install.log
- now pacman installs the code-server package and no warning is printed out

# Notes

My template uses the same installation as in coder examples.

```
resource "coder_agent" "main" {
  os             = "linux"
  arch           = "amd64"
  startup_script = <<EOT
    #!/bin/bash
    # home folder can be empty, so copying default bash settings
    if [ ! -f ~/.profile ]; then
      cp /etc/skel/.profile $HOME
    fi
    if [ ! -f ~/.bashrc ]; then
      cp /etc/skel/.bashrc $HOME
    fi
    # install and start code-server
    curl -fsSL https://code-server.dev/install.sh | sh  | tee code-server-install.log
    code-server --auth none --port 13337 | tee code-server-install.log &
  EOT
}
```

Before I had test with this installation method with an ubuntu based image and everything works fine.