### PR TITLE
chore: update download artifacts in release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -299,8 +299,9 @@ jobs:
           branch: ${{ github.ref }}
           workflow: build.yaml
           workflow_conclusion: completed
-          check_artifacts: true
           name: npm-package
+          check_artifacts: false
+          if_no_artifact_found: fail
 
       - name: Decompress npm package
         run: tar -xzf package.tar.gz


### PR DESCRIPTION
A while back, @code-asher and I discussed improving the "Download artifacts" step in the `release.yaml` workflow. 

These changes make it more "sturdy" because we now `fail` if no artifact found in the latest `completed` `build.yaml` workflow. 

### Pros

- ensures the latest workflow must have the artifact and be completed
- fails if artifacts missing

### Cons
- means doing a release might be slower because you have to wait for their to be a completed workflow 