### PR TITLE
refactor: use npm in build steps and postinstall.sh

### DIFF
--- a/ci/build/build-standalone-release.sh
+++ b/ci/build/build-standalone-release.sh
@@ -10,7 +10,7 @@ main() {
 
   source ./ci/lib.sh
 
-  rsync "$RELEASE_PATH/" "$RELEASE_PATH-standalone"
+  rsync --exclude yarn.lock "$RELEASE_PATH/" "$RELEASE_PATH-standalone"
   RELEASE_PATH+=-standalone
 
   # We cannot find the path to node from $PATH because yarn shims a script to ensure

--- a/ci/build/npm-postinstall.sh
+++ b/ci/build/npm-postinstall.sh
@@ -127,14 +127,6 @@ install_with_yarn_or_npm() {
   # NOTE@edvincent: We want to keep using the package manager that the end-user was using to install the package.
   # This also ensures that when *we* run `yarn` in the development process, the yarn.lock file is used.
   case "${npm_config_user_agent-}" in
-    yarn*)
-      if [ -f "yarn.lock" ]; then
-        yarn --production --frozen-lockfile --no-default-rc
-      else
-        echo "yarn.lock file not present, not running in development mode. use npm to install code-server!"
-        exit 1
-      fi
-      ;;
     npm*)
       if [ -f "yarn.lock" ]; then
         echo "yarn.lock file present, running in development mode. use yarn to install code-server!"
@@ -144,6 +136,14 @@ install_with_yarn_or_npm() {
         # The legacy behavior doesn't complain about pre-releases being used, falling back to that for now.
         # See https://github.com//pull/5071
         npm install --unsafe-perm --legacy-peer-deps --omit=dev
+      fi
+      ;;
+    yarn*)
+      if [ -f "yarn.lock" ]; then
+        yarn --production --frozen-lockfile --no-default-rc
+      else
+        echo "yarn.lock file not present, not running in development mode. use npm to install code-server!"
+        exit 1
       fi
       ;;
     *)


### PR DESCRIPTION
- refactor: default to npm in postinstall.sh
- refactor: exclude yarn.lock in standalone
