### PR TITLE
fix: quote VERSION in jq command in release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -321,7 +321,7 @@ jobs:
 
           echo "Updating version in lib/vscode/product.json"
           tmp=$(mktemp) 
-          jq '.codeServerVersion = "$VERSION"' release/lib/vscode/product.json > "$tmp" && mv "$tmp" release/lib/vscode/product.json
+          jq ".codeServerVersion = \"$VERSION\"" release/lib/vscode/product.json > "$tmp" && mv "$tmp" release/lib/vscode/product.json
           # Ensure it has the same permissions as before
           chmod 644 release/lib/vscode/product.json
 


### PR DESCRIPTION
Tested locally and verified this works

<img width="1712" alt="image" src="https://user-images.githubusercontent.com/3806031/206306976-3a37063a-8521-404e-a483-289181366e5b.png">
