### PR TITLE
chore(nfpm): bump to latest version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Install nfpm and envsubst
         run: |
           mkdir -p ~/.local/bin
-          curl -sSfL https://github.com/goreleaser/nfpm/releases/download/v2.3.1/nfpm_2.3.1_`uname -s`_`uname -m`.tar.gz | tar -C ~/.local/bin -zxv nfpm
+          curl -sSfL https://github.com/goreleaser/nfpm/releases/download/v2.22.2/nfpm_2.22.2_`uname -s`_`uname -m`.tar.gz | tar -C ~/.local/bin -zxv nfpm
           curl -sSfL https://github.com/a8m/envsubst/releases/download/v1.1.0/envsubst-`uname -s`-`uname -m` -o envsubst
           chmod +x envsubst
           mv envsubst ~/.local/bin


### PR DESCRIPTION
Double check I'm seeing this right here but the latest is lower in number...

Latest - https://github.com/goreleaser/nfpm/releases/tag/v2.22.2
The version we use - https://github.com/goreleaser/nfpm/releases/tag/v2.3.1