### PR TITLE
fix: add VERSION to env in publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -127,6 +127,8 @@ jobs:
 
       - name: Validate package
         uses: hapakaien/archlinux-package-action@v2
+        env:
+          VERSION: ${{ env.VERSION }}
         with:
           pkgver: ${{ env.VERSION }}
           updpkgsums: true


### PR DESCRIPTION
When I did the last release, `VERSION` wasn't defined which lead to a
blank string in the PR title and the commit message here:

https://github.com/coder/code-server-aur/pull/24

This should fix that.
