### PR TITLE
refactor: rm node_mods caching in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,22 +67,12 @@ jobs:
       - name: Decompress npm package
         run: tar -xzf package.tar.gz
 
-      - name: Fetch dependencies from cache
-        id: cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: "**/node_modules"
-          key: yarn-build-linux-amd64-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            yarn-build-linux-amd64-
-
       # NOTE: && here is deliberate - GitHub puts each line in its own `.sh`
       # file when running inside a docker container.
       - name: Build standalone release
         run: source scl_source enable devtoolset-9 && npm run release:standalone
 
       - name: Install test dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: SKIP_SUBMODULE_DEPS=1 yarn --frozen-lockfile
 
       - name: Run integration tests on standalone release
@@ -237,20 +227,10 @@ jobs:
       - name: Decompress npm package
         run: tar -xzf package.tar.gz
 
-      - name: Fetch dependencies from cache
-        id: cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: "**/node_modules"
-          key: yarn-build-macos-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            yarn-build-macos-
-
       - name: Build standalone release
         run: npm run release:standalone
 
       - name: Install test dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: SKIP_SUBMODULE_DEPS=1 yarn install
 
       - name: Run native module tests on standalone release


### PR DESCRIPTION
We believe this is causing issues with the 4.9.1 release we're doing right now so we've decide to remove caching in the release workflow for now.