### PR TITLE
chore: update aur job in publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -137,12 +137,14 @@ jobs:
       - name: Open PR
         # We need to git push -u otherwise gh will prompt
         # asking where to push the branch.
+        env:
+          VERSION: ${{ env.VERSION }}
         run: |
-          git checkout -b update-version-${{ steps.version.outputs.version }}
+          git checkout -b update-version-${{ env.VERSION }}
           git add . 
-          git commit -m "chore: updating version to ${{ steps.version.outputs.version }}"
+          git commit -m "chore: updating version to ${{ env.VERSION }}"
           git push -u origin $(git branch --show)
-          gh pr create --repo coder/code-server-aur --title "chore: bump version to ${{ steps.version.outputs.version }}" --body "PR opened by @$GITHUB_ACTOR" --assignee $GITHUB_ACTOR
+          gh pr create --repo coder/code-server-aur --title "chore: bump version to ${{ env.VERSION }}" --body "PR opened by @$GITHUB_ACTOR" --assignee $GITHUB_ACTOR
   docker:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
This uses the `env.VERSION` which should fix the issue with version being blank.

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes N/A
