### PR TITLE
feat(ci): add lint-actions step to build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -147,7 +147,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Check workflow files
         run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash)
           ./actionlint -color -shellcheck= -ignore "set-output"
         shell: bash
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -148,7 +148,7 @@ jobs:
       - name: Check workflow files
         run: |
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint -color -shellcheck=
+          ./actionlint -color -shellcheck= -ignore "set-output"
         shell: bash
 
   test-unit:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -139,6 +139,18 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: yarn lint:ts
 
+  lint-actions:
+    name: Lint GitHub Actions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Check workflow files
+        run: |
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color
+        shell: bash
+
   test-unit:
     name: Run unit tests
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -148,7 +148,7 @@ jobs:
       - name: Check workflow files
         run: |
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint -color
+          ./actionlint -color -shellcheck=
         shell: bash
 
   test-unit:


### PR DESCRIPTION
This adds a new job to the Build CI pipeline to lint our GitHub Actions.

By doing this, we can prevent typos from slipping in.

Fixes #5776
