### PR TITLE
chore: fix requirements so it navigates to docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ access it in the browser.
 
 ## Requirements
 
-See [requirements](requirements.md) for minimum specs, as well as instructions
+See [requirements](https://coder.com/docs/code-server/latest/requirements) for minimum specs, as well as instructions
 on how to set up a Google VM on which you can install code-server.
 
 **TL;DR:** Linux machine with WebSockets enabled, 1 GB RAM, and 2 vCPUs


### PR DESCRIPTION
This was navigating to the relative markdown file, which is confusing when some links go to the docs.
