### PR TITLE
feature: add ability to attach ports to code server

### DIFF
--- a/ci/helm-chart/Chart.yaml
+++ b/ci/helm-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.4.1
+version: 3.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/ci/helm-chart/templates/deployment.yaml
+++ b/ci/helm-chart/templates/deployment.yaml
@@ -114,6 +114,11 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          {{- range .Values.extraPorts }}
+            - name: {{ .name }}
+              containerPort: {{ .port }}
+              protocol: {{ .protocol }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/ci/helm-chart/templates/service.yaml
+++ b/ci/helm-chart/templates/service.yaml
@@ -14,6 +14,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+  {{- range .Values.extraPorts }}
+    - port: {{ .port }}
+      targetPort: {{ .port }}
+      protocol: {{ .protocol }}
+      name: {{ .name }}
+  {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "code-server.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/ci/helm-chart/values.yaml
+++ b/ci/helm-chart/values.yaml
@@ -196,3 +196,8 @@ extraConfigmapMounts: []
   #   subPath: certificates.crt # (optional)
   #   configMap: certs-configmap
   #   readOnly: true
+
+extraPorts: []
+  # - name: minecraft
+  #   port: 25565
+  #   protocol: tcp


### PR DESCRIPTION
This allows the code server that lives within the cluster to be reached by other services in the cluster. Say, for example, a proxy server for Minecraft. 