### PR TITLE
Update Code to 1.76.1

### DIFF
--- a/patches/base-path.diff
+++ b/patches/base-path.diff
@@ -174,7 +174,7 @@ Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
 +			`script-src 'self' 'unsafe-eval' ${this._getScriptCspHashes(data).join(' ')} 'sha256-fh3TwPMflhsEIpR8g1OYTIMVWhXTLcjQ9kh2tIpmv54=';`, // the sha is the same as in src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
  			'child-src \'self\';',
  			`frame-src 'self' https://*.vscode-cdn.net data:;`,
- 			'worker-src \'self\' data:;',
+ 			'worker-src \'self\' data: blob:;',
 @@ -417,3 +421,70 @@ export class WebClientServer {
  		return void res.end(data);
  	}
@@ -250,7 +250,7 @@ Index: code-server/lib/vscode/src/vs/base/common/product.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/base/common/product.ts
 +++ code-server/lib/vscode/src/vs/base/common/product.ts
-@@ -32,6 +32,7 @@ export type ExtensionVirtualWorkspaceSup
+@@ -33,6 +33,7 @@ export type ExtensionVirtualWorkspaceSup
  
  export interface IProductConfiguration {
  	readonly codeServerVersion?: string
@@ -290,7 +290,7 @@ Index: code-server/lib/vscode/src/vs/platform/extensionResourceLoader/common/ext
 -import { RemoteAuthorities } from 'vs/base/common/network';
  import { getRemoteServerRootPath } from 'vs/platform/remote/common/remoteHosts';
  
- export const WEB_EXTENSION_RESOURCE_END_POINT = 'web-extension-resource';
+ const WEB_EXTENSION_RESOURCE_END_POINT = 'web-extension-resource';
 @@ -75,7 +74,7 @@ export abstract class AbstractExtensionR
  	public getExtensionGalleryResourceURL(galleryExtension: { publisher: string; name: string; version: string }, path?: string): URI | undefined {
  		if (this._extensionGalleryResourceUrlTemplate) {

--- a/patches/disable-downloads.diff
+++ b/patches/disable-downloads.diff
@@ -12,7 +12,7 @@ Index: code-server/lib/vscode/src/vs/workbench/browser/web.api.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/browser/web.api.ts
 +++ code-server/lib/vscode/src/vs/workbench/browser/web.api.ts
-@@ -266,6 +266,11 @@ export interface IWorkbenchConstructionO
+@@ -260,6 +260,11 @@ export interface IWorkbenchConstructionO
  	 */
  	readonly userDataPath?: string
  
@@ -172,7 +172,7 @@ Index: code-server/lib/vscode/src/vs/workbench/common/contextkeys.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/common/contextkeys.ts
 +++ code-server/lib/vscode/src/vs/workbench/common/contextkeys.ts
-@@ -32,6 +32,8 @@ export const IsFullscreenContext = new R
+@@ -33,6 +33,8 @@ export const IsFullscreenContext = new R
  
  export const HasWebFileSystemAccess = new RawContextKey<boolean>('hasWebFileSystemAccess', false, true); // Support for FileSystemAccess web APIs (https://wicg.github.io/file-system-access)
  

--- a/patches/display-language.diff
+++ b/patches/display-language.diff
@@ -19,7 +19,7 @@ Index: code-server/lib/vscode/src/vs/server/node/serverServices.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/server/node/serverServices.ts
 +++ code-server/lib/vscode/src/vs/server/node/serverServices.ts
-@@ -220,6 +220,9 @@ export async function setupServerService
+@@ -234,6 +234,9 @@ export async function setupServerService
  		const channel = new ExtensionManagementChannel(extensionManagementService, (ctx: RemoteAgentConnectionContext) => getUriTransformer(ctx.remoteAuthority));
  		socketServer.registerChannel('extensions', channel);
  
@@ -138,7 +138,7 @@ Index: code-server/lib/vscode/src/vs/server/node/remoteLanguagePacks.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/server/node/remoteLanguagePacks.ts
 +++ code-server/lib/vscode/src/vs/server/node/remoteLanguagePacks.ts
-@@ -30,6 +30,12 @@ export function getNLSConfiguration(lang
+@@ -32,6 +32,12 @@ export function getNLSConfiguration(lang
  				if (InternalNLSConfiguration.is(value)) {
  					value._languagePackSupport = true;
  				}
@@ -151,7 +151,7 @@ Index: code-server/lib/vscode/src/vs/server/node/remoteLanguagePacks.ts
  				return value;
  			});
  			_cache.set(key, result);
-@@ -44,3 +50,43 @@ export namespace InternalNLSConfiguratio
+@@ -46,3 +52,43 @@ export namespace InternalNLSConfiguratio
  		return candidate && typeof candidate._languagePackId === 'string';
  	}
  }
@@ -264,9 +264,9 @@ Index: code-server/lib/vscode/src/vs/platform/languagePacks/browser/languagePack
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/platform/languagePacks/browser/languagePacks.ts
 +++ code-server/lib/vscode/src/vs/platform/languagePacks/browser/languagePacks.ts
-@@ -6,18 +6,24 @@
+@@ -5,18 +5,24 @@
+ 
  import { CancellationTokenSource } from 'vs/base/common/cancellation';
- import { Language } from 'vs/base/common/platform';
  import { URI } from 'vs/base/common/uri';
 +import { ProxyChannel } from 'vs/base/parts/ipc/common/ipc';
  import { IExtensionGalleryService } from 'vs/platform/extensionManagement/common/extensionManagement';
@@ -289,8 +289,8 @@ Index: code-server/lib/vscode/src/vs/platform/languagePacks/browser/languagePack
 +		this.languagePackService = ProxyChannel.toService<ILanguagePackService>(remoteAgentService.getConnection()!.getChannel('languagePacks'))
  	}
  
- 	async getBuiltInExtensionTranslationsUri(id: string): Promise<URI | undefined> {
-@@ -73,6 +79,6 @@ export class WebLanguagePacksService ext
+ 	async getBuiltInExtensionTranslationsUri(id: string, language: string): Promise<URI | undefined> {
+@@ -72,6 +78,6 @@ export class WebLanguagePacksService ext
  
  	// Web doesn't have a concept of language packs, so we just return an empty array
  	getInstalledLanguages(): Promise<ILanguagePackItem[]> {
@@ -298,11 +298,11 @@ Index: code-server/lib/vscode/src/vs/platform/languagePacks/browser/languagePack
 +		return this.languagePackService.getInstalledLanguages()
  	}
  }
-Index: code-server/lib/vscode/src/vs/workbench/contrib/localization/electron-sandbox/localeService.ts
+Index: code-server/lib/vscode/src/vs/workbench/services/localization/electron-sandbox/localeService.ts
 ===================================================================
---- code-server.orig/lib/vscode/src/vs/workbench/contrib/localization/electron-sandbox/localeService.ts
-+++ code-server/lib/vscode/src/vs/workbench/contrib/localization/electron-sandbox/localeService.ts
-@@ -41,7 +41,8 @@ export class NativeLocaleService impleme
+--- code-server.orig/lib/vscode/src/vs/workbench/services/localization/electron-sandbox/localeService.ts
++++ code-server/lib/vscode/src/vs/workbench/services/localization/electron-sandbox/localeService.ts
+@@ -51,7 +51,8 @@ class NativeLocaleService implements ILo
  		@IProductService private readonly productService: IProductService
  	) { }
  
@@ -312,7 +312,7 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/localization/electron-san
  		try {
  			const content = await this.textFileService.read(this.environmentService.argvResource, { encoding: 'utf8' });
  
-@@ -68,9 +69,6 @@ export class NativeLocaleService impleme
+@@ -78,9 +79,6 @@ class NativeLocaleService implements ILo
  	}
  
  	private async writeLocaleValue(locale: string | undefined): Promise<boolean> {

--- a/patches/display-language.diff
+++ b/patches/display-language.diff
@@ -14,6 +14,8 @@ We can remove this once upstream supports all language packs.
    one but is worse because it does not handle non-existent or empty files.
 7. Replace some caching and Node requires because code-server does not restart
    when changing the language unlike native Code.
+8. Make language extensions installable like normal rather than using the
+   special set/clear language actions.
 
 Index: code-server/lib/vscode/src/vs/server/node/serverServices.ts
 ===================================================================
@@ -322,3 +324,61 @@ Index: code-server/lib/vscode/src/vs/workbench/services/localization/electron-sa
  		await this.jsonEditingService.write(this.environmentService.argvResource, [{ path: ['locale'], value: locale }], true);
  		return true;
  	}
+Index: code-server/lib/vscode/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
++++ code-server/lib/vscode/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+@@ -318,9 +318,6 @@ export abstract class AbstractInstallAct
+ 		if (this.extension.isBuiltin) {
+ 			return;
+ 		}
+-		if (this.extensionsWorkbenchService.canSetLanguage(this.extension)) {
+-			return;
+-		}
+ 		if (this.extension.state === ExtensionState.Uninstalled && await this.extensionsWorkbenchService.canInstall(this.extension)) {
+ 			this.enabled = this.installPreReleaseVersion ? this.extension.hasPreReleaseVersion : this.extension.hasReleaseVersion;
+ 			this.updateLabel();
+@@ -1785,17 +1782,6 @@ export class SetLanguageAction extends E
+ 	update(): void {
+ 		this.enabled = false;
+ 		this.class = SetLanguageAction.DisabledClass;
+-		if (!this.extension) {
+-			return;
+-		}
+-		if (!this.extensionsWorkbenchService.canSetLanguage(this.extension)) {
+-			return;
+-		}
+-		if (this.extension.gallery && language === getLocale(this.extension.gallery)) {
+-			return;
+-		}
+-		this.enabled = true;
+-		this.class = SetLanguageAction.EnabledClass;
+ 	}
+ 
+ 	override async run(): Promise<any> {
+@@ -1812,7 +1798,6 @@ export class ClearLanguageAction extends
+ 	private static readonly DisabledClass = `${ClearLanguageAction.EnabledClass} disabled`;
+ 
+ 	constructor(
+-		@IExtensionsWorkbenchService private readonly extensionsWorkbenchService: IExtensionsWorkbenchService,
+ 		@ILocaleService private readonly localeService: ILocaleService,
+ 	) {
+ 		super(ClearLanguageAction.ID, ClearLanguageAction.TITLE.value, ClearLanguageAction.DisabledClass, false);
+@@ -1822,17 +1807,6 @@ export class ClearLanguageAction extends
+ 	update(): void {
+ 		this.enabled = false;
+ 		this.class = ClearLanguageAction.DisabledClass;
+-		if (!this.extension) {
+-			return;
+-		}
+-		if (!this.extensionsWorkbenchService.canSetLanguage(this.extension)) {
+-			return;
+-		}
+-		if (this.extension.gallery && language !== getLocale(this.extension.gallery)) {
+-			return;
+-		}
+-		this.enabled = true;
+-		this.class = ClearLanguageAction.EnabledClass;
+ 	}
+ 
+ 	override async run(): Promise<any> {

--- a/patches/display-language.diff
+++ b/patches/display-language.diff
@@ -338,6 +338,15 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/extensions/browser/extens
  		if (this.extension.state === ExtensionState.Uninstalled && await this.extensionsWorkbenchService.canInstall(this.extension)) {
  			this.enabled = this.installPreReleaseVersion ? this.extension.hasPreReleaseVersion : this.extension.hasReleaseVersion;
  			this.updateLabel();
+@@ -697,7 +694,7 @@ export abstract class InstallInOtherServ
+ 		}
+ 
+ 		if (isLanguagePackExtension(this.extension.local.manifest)) {
+-			return true;
++			return false;
+ 		}
+ 
+ 		// Prefers to run on UI
 @@ -1785,17 +1782,6 @@ export class SetLanguageAction extends E
  	update(): void {
  		this.enabled = false;

--- a/patches/display-language.diff
+++ b/patches/display-language.diff
@@ -250,6 +250,15 @@ Index: code-server/lib/vscode/src/vs/workbench/workbench.web.main.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/workbench.web.main.ts
 +++ code-server/lib/vscode/src/vs/workbench/workbench.web.main.ts
+@@ -52,7 +52,7 @@ import 'vs/workbench/services/dialogs/br
+ import 'vs/workbench/services/host/browser/browserHostService';
+ import 'vs/workbench/services/lifecycle/browser/lifecycleService';
+ import 'vs/workbench/services/clipboard/browser/clipboardService';
+-import 'vs/workbench/services/localization/browser/localeService';
++import 'vs/workbench/services/localization/electron-sandbox/localeService';
+ import 'vs/workbench/services/path/browser/pathService';
+ import 'vs/workbench/services/themes/browser/browserHostColorSchemeService';
+ import 'vs/workbench/services/encryption/browser/encryptionService';
 @@ -119,8 +119,9 @@ import 'vs/workbench/contrib/logs/browse
  // Explorer
  import 'vs/workbench/contrib/files/browser/files.web.contribution';

--- a/patches/getting-started.diff
+++ b/patches/getting-started.diff
@@ -143,7 +143,7 @@ Index: code-server/lib/vscode/src/vs/workbench/browser/web.api.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/browser/web.api.ts
 +++ code-server/lib/vscode/src/vs/workbench/browser/web.api.ts
-@@ -271,6 +271,11 @@ export interface IWorkbenchConstructionO
+@@ -265,6 +265,11 @@ export interface IWorkbenchConstructionO
  	 */
  	readonly isEnabledFileDownloads?: boolean
  
@@ -201,7 +201,7 @@ Index: code-server/lib/vscode/src/vs/server/node/serverEnvironmentService.ts
  	'auth'?: string
  	'disable-file-downloads'?: boolean;
  	'locale'?: string
-+	'disable-getting-started-override'?: boolean;
++	'disable-getting-started-override'?: boolean,
  
  	/* ----- server setup ----- */
  
@@ -242,7 +242,7 @@ Index: code-server/lib/vscode/src/vs/workbench/common/contextkeys.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/common/contextkeys.ts
 +++ code-server/lib/vscode/src/vs/workbench/common/contextkeys.ts
-@@ -33,6 +33,7 @@ export const IsFullscreenContext = new R
+@@ -34,6 +34,7 @@ export const IsFullscreenContext = new R
  export const HasWebFileSystemAccess = new RawContextKey<boolean>('hasWebFileSystemAccess', false, true); // Support for FileSystemAccess web APIs (https://wicg.github.io/file-system-access)
  
  export const IsEnabledFileDownloads = new RawContextKey<boolean>('isEnabledFileDownloads', true, true);

--- a/patches/integration.diff
+++ b/patches/integration.diff
@@ -107,7 +107,7 @@ Index: code-server/lib/vscode/src/vs/workbench/browser/parts/dialogs/dialogHandl
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
 +++ code-server/lib/vscode/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
-@@ -145,8 +145,11 @@ export class BrowserDialogHandler implem
+@@ -76,8 +76,11 @@ export class BrowserDialogHandler extend
  
  	async about(): Promise<void> {
  		const detailString = (useAgo: boolean): string => {
@@ -198,7 +198,7 @@ Index: code-server/lib/vscode/src/vs/base/common/product.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/base/common/product.ts
 +++ code-server/lib/vscode/src/vs/base/common/product.ts
-@@ -31,6 +31,8 @@ export type ExtensionVirtualWorkspaceSup
+@@ -32,6 +32,8 @@ export type ExtensionVirtualWorkspaceSup
  };
  
  export interface IProductConfiguration {

--- a/patches/local-storage.diff
+++ b/patches/local-storage.diff
@@ -32,7 +32,7 @@ Index: code-server/lib/vscode/src/vs/workbench/browser/web.api.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/browser/web.api.ts
 +++ code-server/lib/vscode/src/vs/workbench/browser/web.api.ts
-@@ -261,6 +261,11 @@ export interface IWorkbenchConstructionO
+@@ -255,6 +255,11 @@ export interface IWorkbenchConstructionO
  	 */
  	readonly configurationDefaults?: Record<string, any>;
  

--- a/patches/logout.diff
+++ b/patches/logout.diff
@@ -8,7 +8,7 @@ Index: code-server/lib/vscode/src/vs/base/common/product.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/base/common/product.ts
 +++ code-server/lib/vscode/src/vs/base/common/product.ts
-@@ -34,6 +34,7 @@ export interface IProductConfiguration {
+@@ -35,6 +35,7 @@ export interface IProductConfiguration {
  	readonly codeServerVersion?: string
  	readonly rootEndpoint?: string
  	readonly updateEndpoint?: string

--- a/patches/marketplace.diff
+++ b/patches/marketplace.diff
@@ -75,7 +75,7 @@ Index: code-server/lib/vscode/src/vs/platform/extensionResourceLoader/common/ext
  import { getTelemetryLevel, supportsTelemetry } from 'vs/platform/telemetry/common/telemetryUtils';
 -import { getRemoteServerRootPath } from 'vs/platform/remote/common/remoteHosts';
  
- export const WEB_EXTENSION_RESOURCE_END_POINT = 'web-extension-resource';
+ const WEB_EXTENSION_RESOURCE_END_POINT = 'web-extension-resource';
  
 @@ -60,7 +59,7 @@ export abstract class AbstractExtensionR
  		private readonly _environmentService: IEnvironmentService,

--- a/patches/proposed-api.diff
+++ b/patches/proposed-api.diff
@@ -10,7 +10,7 @@ Index: code-server/lib/vscode/src/vs/workbench/services/extensions/common/abstra
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
 +++ code-server/lib/vscode/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
-@@ -1486,7 +1486,7 @@ class ProposedApiController {
+@@ -1488,7 +1488,7 @@ class ProposedApiController {
  
  		this._envEnabledExtensions = new Set((_environmentService.extensionEnabledProposedApi ?? []).map(id => ExtensionIdentifier.toKey(id)));
  

--- a/patches/proxy-uri.diff
+++ b/patches/proxy-uri.diff
@@ -30,7 +30,7 @@ Index: code-server/lib/vscode/src/vs/base/common/product.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/base/common/product.ts
 +++ code-server/lib/vscode/src/vs/base/common/product.ts
-@@ -35,6 +35,7 @@ export interface IProductConfiguration {
+@@ -36,6 +36,7 @@ export interface IProductConfiguration {
  	readonly rootEndpoint?: string
  	readonly updateEndpoint?: string
  	readonly logoutEndpoint?: string

--- a/patches/service-worker.diff
+++ b/patches/service-worker.diff
@@ -6,7 +6,7 @@ Index: code-server/lib/vscode/src/vs/base/common/product.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/base/common/product.ts
 +++ code-server/lib/vscode/src/vs/base/common/product.ts
-@@ -36,6 +36,10 @@ export interface IProductConfiguration {
+@@ -37,6 +37,10 @@ export interface IProductConfiguration {
  	readonly updateEndpoint?: string
  	readonly logoutEndpoint?: string
  	readonly proxyEndpointTemplate?: string

--- a/patches/sourcemaps.diff
+++ b/patches/sourcemaps.diff
@@ -10,7 +10,7 @@ Index: code-server/lib/vscode/build/gulpfile.reh.js
 ===================================================================
 --- code-server.orig/lib/vscode/build/gulpfile.reh.js
 +++ code-server/lib/vscode/build/gulpfile.reh.js
-@@ -192,8 +192,7 @@ function packageTask(type, platform, arc
+@@ -191,8 +191,7 @@ function packageTask(type, platform, arc
  
  		const src = gulp.src(sourceFolderName + '/**', { base: '.' })
  			.pipe(rename(function (path) { path.dirname = path.dirname.replace(new RegExp('^' + sourceFolderName), 'out'); }))
@@ -20,7 +20,7 @@ Index: code-server/lib/vscode/build/gulpfile.reh.js
  
  		const workspaceExtensionPoints = ['debuggers', 'jsonValidation'];
  		const isUIExtension = (manifest) => {
-@@ -232,9 +231,9 @@ function packageTask(type, platform, arc
+@@ -231,9 +230,9 @@ function packageTask(type, platform, arc
  			.map(name => `.build/extensions/${name}/**`);
  
  		const extensions = gulp.src(extensionPaths, { base: '.build', dot: true });
@@ -32,7 +32,7 @@ Index: code-server/lib/vscode/build/gulpfile.reh.js
  
  		let version = packageJson.version;
  		const quality = product.quality;
-@@ -389,7 +388,7 @@ function tweakProductForServerWeb(produc
+@@ -388,7 +387,7 @@ function tweakProductForServerWeb(produc
  	const minifyTask = task.define(`minify-vscode-${type}`, task.series(
  		optimizeTask,
  		util.rimraf(`out-vscode-${type}-min`),

--- a/patches/telemetry.diff
+++ b/patches/telemetry.diff
@@ -20,8 +20,8 @@ Index: code-server/lib/vscode/src/vs/server/node/serverServices.ts
  import { NullPolicyService } from 'vs/platform/policy/common/policy';
  import { OneDataSystemAppender } from 'vs/platform/telemetry/node/1dsAppender';
  import { LoggerService } from 'vs/platform/log/node/loggerService';
-@@ -142,10 +143,13 @@ export async function setupServerService
- 	const machineId = await getMachineId();
+@@ -151,10 +152,13 @@ export async function setupServerService
+ 	let oneDsAppender: ITelemetryAppender = NullAppender;
  	const isInternal = isInternalTelemetry(productService, configurationService);
  	if (supportsTelemetry(productService, environmentService)) {
 -		if (productService.aiConfig && productService.aiConfig.ariaKey) {

--- a/patches/update-check.diff
+++ b/patches/update-check.diff
@@ -93,7 +93,7 @@ Index: code-server/lib/vscode/src/vs/base/common/product.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/base/common/product.ts
 +++ code-server/lib/vscode/src/vs/base/common/product.ts
-@@ -33,6 +33,7 @@ export type ExtensionVirtualWorkspaceSup
+@@ -34,6 +34,7 @@ export type ExtensionVirtualWorkspaceSup
  export interface IProductConfiguration {
  	readonly codeServerVersion?: string
  	readonly rootEndpoint?: string

--- a/patches/webview.diff
+++ b/patches/webview.diff
@@ -62,15 +62,6 @@ Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
  			_wrapWebWorkerExtHostInIframe,
  			developmentOptions: { enableSmokeTestDriver: this._environmentService.args['enable-smoke-test-driver'] ? true : undefined, logLevel: this._logService.getLevel() },
  			settingsSyncOptions: !this._environmentService.isBuilt && this._environmentService.args['enable-sync'] ? { enabled: true } : undefined,
-@@ -344,7 +345,7 @@ export class WebClientServer {
- 			`script-src 'self' 'unsafe-eval' ${this._getScriptCspHashes(data).join(' ')} 'sha256-fh3TwPMflhsEIpR8g1OYTIMVWhXTLcjQ9kh2tIpmv54=';`, // the sha is the same as in src/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
- 			'child-src \'self\';',
- 			`frame-src 'self' https://*.vscode-cdn.net data:;`,
--			'worker-src \'self\' data:;',
-+			'worker-src \'self\' data: blob:;',
- 			'style-src \'self\' \'unsafe-inline\';',
- 			'connect-src \'self\' ws: wss: https:;',
- 			'font-src \'self\' blob:;',
 Index: code-server/lib/vscode/src/vs/workbench/contrib/webview/browser/pre/index.html
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/contrib/webview/browser/pre/index.html


### PR DESCRIPTION
- worker-src already contains blob so we can avoid patching that.
- localeService moved.
- Remaining changes were just line changes.
- Make language extensions installable again.
- Remove broken "install in browser" for language packs.
- Replace new locale import.

Closes #6050
