### PR TITLE
Allow app-name configuration to change the name of the PWA

### DIFF
--- a/src/node/routes/vscode.ts
+++ b/src/node/routes/vscode.ts
@@ -40,6 +40,7 @@ export class CodeServerRouteWrapper {
   //#region Route Handlers
 
   private manifest: express.Handler = async (req, res, next) => {
+    const appName = req.args["app-name"] || "code-server"
     res.writeHead(200, { "Content-Type": "application/manifest+json" })
 
     return res.end(
@@ -47,8 +48,8 @@ export class CodeServerRouteWrapper {
         req,
         JSON.stringify(
           {
-            name: "code-server",
-            short_name: "code-server",
+            name: appName,
+            short_name: appName,
             start_url: ".",
             display: "fullscreen",
             description: "Run Code on a remote server.",


### PR DESCRIPTION
Fixes #
if I have multiple instances for code-server running for every user and I want to install the PWA the name currently defaults to "code-server" which overrides the desktop shortcut.
This fix allows multiple instances to be installed with customizable names.

