### PR TITLE
Prefer matching editor sessions when opening files.

### DIFF
--- a/patches/store-socket.diff
+++ b/patches/store-socket.diff
@@ -1,4 +1,4 @@
-Store a static reference to the IPC socket
+Store the IPC socket with workspace metadata.
 
 This lets us use it to open files inside code-server from outside of
 code-server.
@@ -9,6 +9,8 @@ To test this:
 
 It should open in your existing code-server instance.
 
+When the extension host is terminated, the socket is unregistered.
+
 Index: code-server/lib/vscode/src/vs/workbench/api/node/extHostExtensionService.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/api/node/extHostExtensionService.ts
@@ -18,20 +20,114 @@ Index: code-server/lib/vscode/src/vs/workbench/api/node/extHostExtensionService.
   *  Licensed under the MIT License. See License.txt in the project root for license information.
   *--------------------------------------------------------------------------------------------*/
 -
-+import { promises as fs } from 'fs';
-+import * as os from 'os'
++import * as os from 'os';
++import * as _http from 'http';
 +import * as path from 'vs/base/common/path';
  import * as performance from 'vs/base/common/performance';
  import { createApiFactoryAndRegisterActors } from 'vs/workbench/api/common/extHost.api.impl';
  import { RequireInterceptor } from 'vs/workbench/api/common/extHostRequireInterceptor';
-@@ -72,6 +74,10 @@ export class ExtHostExtensionService ext
- 		if (this._initData.remote.isRemote && this._initData.remote.authority) {
- 			const cliServer = this._instaService.createInstance(CLIServer);
- 			process.env['VSCODE_IPC_HOOK_CLI'] = cliServer.ipcHandlePath;
-+
-+			fs.writeFile(path.join(os.tmpdir(), 'vscode-ipc'), cliServer.ipcHandlePath).catch((error) => {
-+				this._logService.error(error);
-+			});
- 		}
+@@ -17,6 +19,7 @@ import { ExtensionRuntime } from 'vs/wor
+ import { CLIServer } from 'vs/workbench/api/node/extHostCLIServer';
+ import { realpathSync } from 'vs/base/node/extpath';
+ import { ExtHostConsoleForwarder } from 'vs/workbench/api/node/extHostConsoleForwarder';
++import { IExtHostWorkspace } from '../common/extHostWorkspace';
  
- 		// Module loading tricks
+ class NodeModuleRequireInterceptor extends RequireInterceptor {
+ 
+@@ -79,6 +82,52 @@ export class ExtHostExtensionService ext
+ 		await interceptor.install();
+ 		performance.mark('code/extHost/didInitAPI');
+ 
++		(async () => {
++			const socketPath = process.env['VSCODE_IPC_HOOK_CLI'];
++			if (!socketPath) {
++				return;
++			}
++			const workspace = this._instaService.invokeFunction((accessor) => {
++				const workspaceService = accessor.get(IExtHostWorkspace);
++				return workspaceService.workspace;
++			});
++			const entry = {
++				workspace,
++				socketPath
++			};
++			const message = JSON.stringify({entry});
++			const codeServerSocketPath = path.join(os.tmpdir(), 'code-server-ipc.sock');
++			await new Promise<void>((resolve, reject) => {
++				const opts: _http.RequestOptions = {
++					path: '/add-session',
++					socketPath: codeServerSocketPath,
++					method: 'POST',
++					headers: {
++						'content-type': 'application/json',
++					}
++				};
++				const req = _http.request(opts, (res) => {
++					res.on('error', reject);
++					res.on('end', () => {
++						try {
++							if (res.statusCode === 200) {
++								resolve();
++							} else {
++								reject(new Error('Unexpected status code: ' + res.statusCode));
++							}
++						} catch (e: unknown) {
++							reject(e);
++						}
++					});
++				});
++				req.on('error', reject);
++				req.write(message);
++				req.end();
++			});
++		})().catch(error => {
++			this._logService.error(error);
++		});
++
+ 		// Do this when extension service exists, but extensions are not being activated yet.
+ 		const configProvider = await this._extHostConfiguration.getConfigProvider();
+ 		await connectProxyResolver(this._extHostWorkspace, configProvider, this, this._logService, this._mainThreadTelemetryProxy, this._initData);
+Index: code-server/lib/vscode/src/vs/workbench/api/node/extensionHostProcess.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/workbench/api/node/extensionHostProcess.ts
++++ code-server/lib/vscode/src/vs/workbench/api/node/extensionHostProcess.ts
+@@ -3,6 +3,9 @@
+  *  Licensed under the MIT License. See License.txt in the project root for license information.
+  *--------------------------------------------------------------------------------------------*/
+ 
++import * as os from 'os';
++import * as _http from 'http';
++import * as path from 'vs/base/common/path';
+ import * as nativeWatchdog from 'native-watchdog';
+ import * as net from 'net';
+ import * as minimist from 'minimist';
+@@ -400,7 +403,28 @@ async function startExtensionHostProcess
+ 	);
+ 
+ 	// rewrite onTerminate-function to be a proper shutdown
+-	onTerminate = (reason: string) => extensionHostMain.terminate(reason);
++	onTerminate = (reason: string) => {
++		extensionHostMain.terminate(reason);
++
++		const socketPath = process.env['VSCODE_IPC_HOOK_CLI'];
++		if (!socketPath) {
++			return;
++		}
++		const message = JSON.stringify({socketPath});
++		const codeServerSocketPath = path.join(os.tmpdir(), 'code-server-ipc.sock');
++		const opts: _http.RequestOptions = {
++			path: '/delete-session',
++			socketPath: codeServerSocketPath,
++			method: 'POST',
++			headers: {
++				'content-type': 'application/json',
++				'accept': 'application/json'
++			}
++		};
++		const req = _http.request(opts);
++		req.write(message);
++		req.end();
++	};
+ }
+ 
+ startExtensionHostProcess().catch((err) => console.log(err));

--- a/src/node/app.ts
+++ b/src/node/app.ts
@@ -9,9 +9,11 @@ import * as util from "../common/util"
 import { DefaultedArgs } from "./cli"
 import { disposer } from "./http"
 import { isNodeJSErrnoException } from "./util"
+import { DEFAULT_SOCKET_PATH, EditorSessionManager, makeEditorSessionManagerServer } from "./vscodeSocket"
 import { handleUpgrade } from "./wsRouter"
 
-type ListenOptions = Pick<DefaultedArgs, "socket-mode" | "socket" | "port" | "host">
+type SocketOptions = { socket: string; "socket-mode"?: string }
+type ListenOptions = DefaultedArgs | SocketOptions
 
 export interface App extends Disposable {
   /** Handles regular HTTP requests. */
@@ -20,12 +22,18 @@ export interface App extends Disposable {
   wsRouter: Express
   /** The underlying HTTP server. */
   server: http.Server
+  /** Handles requests to the editor session management API. */
+  editorSessionManagerServer: http.Server
 }
 
-export const listen = async (server: http.Server, { host, port, socket, "socket-mode": mode }: ListenOptions) => {
-  if (socket) {
+const isSocketOpts = (opts: ListenOptions): opts is SocketOptions => {
+  return !!(opts as SocketOptions).socket || !(opts as DefaultedArgs).host
+}
+
+export const listen = async (server: http.Server, opts: ListenOptions) => {
+  if (isSocketOpts(opts)) {
     try {
-      await fs.unlink(socket)
+      await fs.unlink(opts.socket)
     } catch (error: any) {
       handleArgsSocketCatchError(error)
     }
@@ -38,18 +46,20 @@ export const listen = async (server: http.Server, { host, port, socket, "socket-
       server.on("error", (err) => util.logError(logger, "http server error", err))
       resolve()
     }
-    if (socket) {
-      server.listen(socket, onListen)
+    if (isSocketOpts(opts)) {
+      server.listen(opts.socket, onListen)
     } else {
       // [] is the correct format when using :: but Node errors with them.
-      server.listen(port, host.replace(/^\[|\]$/g, ""), onListen)
+      server.listen(opts.port, opts.host.replace(/^\[|\]$/g, ""), onListen)
     }
   })
 
   // NOTE@jsjoeio: we need to chmod after the server is finished
   // listening. Otherwise, the socket may not have been created yet.
-  if (socket && mode) {
-    await fs.chmod(socket, mode)
+  if (isSocketOpts(opts)) {
+    if (opts["socket-mode"]) {
+      await fs.chmod(opts.socket, opts["socket-mode"])
+    }
   }
 }
 
@@ -70,14 +80,22 @@ export const createApp = async (args: DefaultedArgs): Promise<App> => {
       )
     : http.createServer(router)
 
-  const dispose = disposer(server)
+  const disposeServer = disposer(server)
 
   await listen(server, args)
 
   const wsRouter = express()
   handleUpgrade(wsRouter, server)
 
-  return { router, wsRouter, server, dispose }
+  const editorSessionManager = new EditorSessionManager()
+  const editorSessionManagerServer = await makeEditorSessionManagerServer(DEFAULT_SOCKET_PATH, editorSessionManager)
+  const disposeEditorSessionManagerServer = disposer(editorSessionManagerServer)
+
+  const dispose = async () => {
+    await Promise.all([disposeServer(), disposeEditorSessionManagerServer()])
+  }
+
+  return { router, wsRouter, server, dispose, editorSessionManagerServer }
 }
 
 /**

--- a/src/node/main.ts
+++ b/src/node/main.ts
@@ -1,7 +1,6 @@
 import { field, logger } from "@coder/logger"
 import http from "http"
 import * as os from "os"
-import path from "path"
 import { Disposable } from "../common/emitter"
 import { plural } from "../common/util"
 import { createApp, ensureAddress } from "./app"
@@ -70,9 +69,8 @@ export const openInExistingInstance = async (args: DefaultedArgs, socketPath: st
     forceNewWindow: args["new-window"],
     gotoLineMode: true,
   }
-  const paths = args._ || []
-  for (let i = 0; i < paths.length; i++) {
-    const fp = path.resolve(paths[i])
+  for (let i = 0; i < args._.length; i++) {
+    const fp = args._[i]
     if (await isDirectory(fp)) {
       pipeArgs.folderURIs.push(fp)
     } else {
@@ -123,10 +121,12 @@ export const runCodeServer = async (
   const app = await createApp(args)
   const protocol = args.cert ? "https" : "http"
   const serverAddress = ensureAddress(app.server, protocol)
+  const sessionServerAddress = app.editorSessionManagerServer.address()
   const disposeRoutes = await register(app, args)
 
   logger.info(`Using config file ${humanPath(os.homedir(), args.config)}`)
   logger.info(`${protocol.toUpperCase()} server listening on ${serverAddress.toString()}`)
+  logger.info(`Session server listening on ${sessionServerAddress?.toString()}`)
 
   if (args.auth === AuthType.Password) {
     logger.info("  - Authentication is enabled")

--- a/src/node/vscodeSocket.ts
+++ b/src/node/vscodeSocket.ts
@@ -1,0 +1,206 @@
+import { logger } from "@coder/logger"
+import express from "express"
+import * as http from "http"
+import * as os from "os"
+import * as path from "path"
+import { HttpCode } from "../common/http"
+import { listen } from "./app"
+import { canConnect } from "./util"
+
+// Socket path of the daemonized code-server instance.
+export const DEFAULT_SOCKET_PATH = path.join(os.tmpdir(), "code-server-ipc.sock")
+
+export interface EditorSessionEntry {
+  workspace: {
+    id: string
+    folders: {
+      uri: {
+        path: string
+      }
+    }[]
+  }
+
+  socketPath: string
+}
+
+interface DeleteSessionRequest {
+  socketPath: string
+}
+
+interface AddSessionRequest {
+  entry: EditorSessionEntry
+}
+
+interface GetSessionResponse {
+  socketPath?: string
+}
+
+export async function makeEditorSessionManagerServer(
+  codeServerSocketPath: string,
+  editorSessionManager: EditorSessionManager,
+): Promise<http.Server> {
+  const router = express()
+
+  // eslint-disable-next-line import/no-named-as-default-member
+  router.use(express.json())
+
+  router.get("/session", async (req, res) => {
+    const filePath = req.query.filePath as string
+    if (!filePath) {
+      res.status(HttpCode.BadRequest).send("filePath is required")
+      return
+    }
+    try {
+      const socketPath = await editorSessionManager.getConnectedSocketPath(filePath)
+      const response: GetSessionResponse = { socketPath }
+      res.json(response)
+    } catch (error: unknown) {
+      res.status(HttpCode.ServerError).send(error)
+    }
+  })
+
+  router.post("/add-session", async (req, res) => {
+    const request = req.body as AddSessionRequest
+    if (!request.entry) {
+      res.status(400).send("entry is required")
+    }
+    editorSessionManager.addSession(request.entry)
+    res.status(200).send()
+  })
+
+  router.post("/delete-session", async (req, res) => {
+    const request = req.body as DeleteSessionRequest
+    if (!request.socketPath) {
+      res.status(400).send("socketPath is required")
+    }
+    editorSessionManager.deleteSession(request.socketPath)
+    res.status(200).send()
+  })
+
+  const server = http.createServer(router)
+  await listen(server, { socket: codeServerSocketPath })
+  return server
+}
+
+export class EditorSessionManager {
+  // Map from socket path to EditorSessionEntry.
+  private entries = new Map<string, EditorSessionEntry>()
+
+  addSession(entry: EditorSessionEntry): void {
+    logger.debug(`Adding session to session registry: ${entry.socketPath}`)
+    this.entries.set(entry.socketPath, entry)
+  }
+
+  getCandidatesForFile(filePath: string): EditorSessionEntry[] {
+    const matchCheckResults = new Map<string, boolean>()
+
+    const checkMatch = (entry: EditorSessionEntry): boolean => {
+      if (matchCheckResults.has(entry.socketPath)) {
+        return matchCheckResults.get(entry.socketPath)!
+      }
+      const result = entry.workspace.folders.some((folder) => filePath.startsWith(folder.uri.path + path.sep))
+      matchCheckResults.set(entry.socketPath, result)
+      return result
+    }
+
+    return Array.from(this.entries.values())
+      .reverse() // Most recently registered first.
+      .sort((a, b) => {
+        // Matches first.
+        const aMatch = checkMatch(a)
+        const bMatch = checkMatch(b)
+        if (aMatch === bMatch) {
+          return 0
+        }
+        if (aMatch) {
+          return -1
+        }
+        return 1
+      })
+  }
+
+  deleteSession(socketPath: string): void {
+    logger.debug(`Deleting session from session registry: ${socketPath}`)
+    this.entries.delete(socketPath)
+  }
+
+  /**
+   * Returns the best socket path that we can connect to.
+   * We also delete any sockets that we can't connect to.
+   */
+  async getConnectedSocketPath(filePath: string): Promise<string | undefined> {
+    const candidates = this.getCandidatesForFile(filePath)
+    let match: EditorSessionEntry | undefined = undefined
+
+    for (const candidate of candidates) {
+      if (await canConnect(candidate.socketPath)) {
+        match = candidate
+        break
+      }
+      this.deleteSession(candidate.socketPath)
+    }
+
+    return match?.socketPath
+  }
+}
+
+export class EditorSessionManagerClient {
+  constructor(private codeServerSocketPath: string) {}
+
+  async canConnect() {
+    return canConnect(this.codeServerSocketPath)
+  }
+
+  async getConnectedSocketPath(filePath: string): Promise<string | undefined> {
+    const response = await new Promise<GetSessionResponse>((resolve, reject) => {
+      const opts = {
+        path: "/session?filePath=" + encodeURIComponent(filePath),
+        socketPath: this.codeServerSocketPath,
+        method: "GET",
+      }
+      const req = http.request(opts, (res) => {
+        let rawData = ""
+        res.setEncoding("utf8")
+        res.on("data", (chunk) => {
+          rawData += chunk
+        })
+        res.on("end", () => {
+          try {
+            const obj = JSON.parse(rawData)
+            if (res.statusCode === 200) {
+              resolve(obj)
+            } else {
+              reject(new Error("Unexpected status code: " + res.statusCode))
+            }
+          } catch (e: unknown) {
+            reject(e)
+          }
+        })
+      })
+      req.on("error", reject)
+      req.end()
+    })
+    return response.socketPath
+  }
+
+  // Currently only used for tests.
+  async addSession(request: AddSessionRequest): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      const opts = {
+        path: "/add-session",
+        socketPath: this.codeServerSocketPath,
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json",
+        },
+      }
+      const req = http.request(opts, () => {
+        resolve()
+      })
+      req.on("error", reject)
+      req.write(JSON.stringify(request))
+      req.end()
+    })
+  }
+}

--- a/test/unit/node/app.test.ts
+++ b/test/unit/node/app.test.ts
@@ -17,7 +17,7 @@ describe("createApp", () => {
   beforeAll(async () => {
     mockLogger()
 
-    const testName = "unlink-socket"
+    const testName = "app"
     await clean(testName)
     tmpDirPath = await tmpdir(testName)
     tmpFilePath = path.join(tmpDirPath, "unlink-socket-file")
@@ -103,7 +103,7 @@ describe("createApp", () => {
 
     const app = await createApp(defaultArgs)
 
-    expect(unlinkSpy).toHaveBeenCalledTimes(1)
+    expect(unlinkSpy).toHaveBeenCalledWith(tmpFilePath)
     app.dispose()
   })
 

--- a/test/unit/node/vscodeSocket.test.ts
+++ b/test/unit/node/vscodeSocket.test.ts
@@ -1,0 +1,243 @@
+import { EditorSessionManager } from "../../../src/node/vscodeSocket"
+import { clean, tmpdir, listenOn } from "../../utils/helpers"
+
+describe("EditorSessionManager", () => {
+  let tmpDirPath: string
+
+  const testName = "esm"
+
+  beforeAll(async () => {
+    await clean(testName)
+  })
+
+  beforeEach(async () => {
+    tmpDirPath = await tmpdir(testName)
+  })
+
+  describe("getCandidatesForFile", () => {
+    it("should prefer the last added socket path for a matching path", async () => {
+      const manager = new EditorSessionManager()
+      manager.addSession({
+        workspace: {
+          id: "aaa",
+          folders: [
+            {
+              uri: {
+                path: "/aaa",
+              },
+            },
+          ],
+        },
+        socketPath: `${tmpDirPath}/vscode-ipc-aaa-1.sock`,
+      })
+      manager.addSession({
+        workspace: {
+          id: "aaa",
+          folders: [
+            {
+              uri: {
+                path: "/aaa",
+              },
+            },
+          ],
+        },
+        socketPath: `${tmpDirPath}/vscode-ipc-aaa-2.sock`,
+      })
+      manager.addSession({
+        workspace: {
+          id: "bbb",
+          folders: [
+            {
+              uri: {
+                path: "/bbb",
+              },
+            },
+          ],
+        },
+        socketPath: `${tmpDirPath}/vscode-ipc-bbb.sock`,
+      })
+      const socketPaths = manager.getCandidatesForFile("/aaa/some-file:1:1")
+      expect(socketPaths.map((x) => x.socketPath)).toEqual([
+        // Matches
+        `${tmpDirPath}/vscode-ipc-aaa-2.sock`,
+        `${tmpDirPath}/vscode-ipc-aaa-1.sock`,
+        // Non-matches
+        `${tmpDirPath}/vscode-ipc-bbb.sock`,
+      ])
+    })
+
+    it("should return the last added socketPath if there are no matches", async () => {
+      const manager = new EditorSessionManager()
+      manager.addSession({
+        workspace: {
+          id: "aaa",
+          folders: [
+            {
+              uri: {
+                path: "/aaa",
+              },
+            },
+          ],
+        },
+        socketPath: `${tmpDirPath}/vscode-ipc-aaa.sock`,
+      })
+      manager.addSession({
+        workspace: {
+          id: "bbb",
+          folders: [
+            {
+              uri: {
+                path: "/bbb",
+              },
+            },
+          ],
+        },
+        socketPath: `${tmpDirPath}/vscode-ipc-bbb.sock`,
+      })
+      const socketPaths = manager.getCandidatesForFile("/ccc/some-file:1:1")
+      expect(socketPaths.map((x) => x.socketPath)).toEqual([
+        `${tmpDirPath}/vscode-ipc-bbb.sock`,
+        `${tmpDirPath}/vscode-ipc-aaa.sock`,
+      ])
+    })
+
+    it("does not just directly do a substring match", async () => {
+      const manager = new EditorSessionManager()
+      manager.addSession({
+        workspace: {
+          id: "aaa",
+          folders: [
+            {
+              uri: {
+                path: "/aaa",
+              },
+            },
+          ],
+        },
+        socketPath: `${tmpDirPath}/vscode-ipc-aaa.sock`,
+      })
+      manager.addSession({
+        workspace: {
+          id: "bbb",
+          folders: [
+            {
+              uri: {
+                path: "/bbb",
+              },
+            },
+          ],
+        },
+        socketPath: `${tmpDirPath}/vscode-ipc-bbb.sock`,
+      })
+      const entries = manager.getCandidatesForFile("/aaaxxx/some-file:1:1")
+      expect(entries.map((x) => x.socketPath)).toEqual([
+        `${tmpDirPath}/vscode-ipc-bbb.sock`,
+        `${tmpDirPath}/vscode-ipc-aaa.sock`,
+      ])
+    })
+  })
+
+  describe("getConnectedSocketPath", () => {
+    it("should return socket path if socket is active", async () => {
+      listenOn(`${tmpDirPath}/vscode-ipc-aaa.sock`).once()
+      const manager = new EditorSessionManager()
+      manager.addSession({
+        workspace: {
+          id: "aaa",
+          folders: [
+            {
+              uri: {
+                path: "/aaa",
+              },
+            },
+          ],
+        },
+        socketPath: `${tmpDirPath}/vscode-ipc-aaa.sock`,
+      })
+      const socketPath = await manager.getConnectedSocketPath("/aaa/some-file:1:1")
+      expect(socketPath).toBe(`${tmpDirPath}/vscode-ipc-aaa.sock`)
+    })
+
+    it("should return undefined if socket is inactive", async () => {
+      const manager = new EditorSessionManager()
+      manager.addSession({
+        workspace: {
+          id: "aaa",
+          folders: [
+            {
+              uri: {
+                path: "/aaa",
+              },
+            },
+          ],
+        },
+        socketPath: `${tmpDirPath}/vscode-ipc-aaa.sock`,
+      })
+      const socketPath = await manager.getConnectedSocketPath("/aaa/some-file:1:1")
+      expect(socketPath).toBeUndefined()
+    })
+
+    it("should return undefined given no matching active sockets", async () => {
+      const vscodeSockets = listenOn(`${tmpDirPath}/vscode-ipc-bbb.sock`)
+      const manager = new EditorSessionManager()
+      manager.addSession({
+        workspace: {
+          id: "aaa",
+          folders: [
+            {
+              uri: {
+                path: "/aaa",
+              },
+            },
+          ],
+        },
+        socketPath: `${tmpDirPath}/vscode-ipc-aaa.sock`,
+      })
+      const socketPath = await manager.getConnectedSocketPath("/aaa/some-file:1:1")
+      expect(socketPath).toBeUndefined()
+      vscodeSockets.close()
+    })
+
+    it("should return undefined if there are no entries", async () => {
+      const manager = new EditorSessionManager()
+      const socketPath = await manager.getConnectedSocketPath("/aaa/some-file:1:1")
+      expect(socketPath).toBeUndefined()
+    })
+
+    it("should return most recently used socket path available", async () => {
+      listenOn(`${tmpDirPath}/vscode-ipc-aaa-1.sock`).once()
+      const manager = new EditorSessionManager()
+      manager.addSession({
+        workspace: {
+          id: "aaa",
+          folders: [
+            {
+              uri: {
+                path: "/aaa",
+              },
+            },
+          ],
+        },
+        socketPath: `${tmpDirPath}/vscode-ipc-aaa-1.sock`,
+      })
+      manager.addSession({
+        workspace: {
+          id: "aaa",
+          folders: [
+            {
+              uri: {
+                path: "/aaa",
+              },
+            },
+          ],
+        },
+        socketPath: `${tmpDirPath}/vscode-ipc-aaa-2.sock`,
+      })
+
+      const socketPath = await manager.getConnectedSocketPath("/aaa/some-file:1:1")
+      expect(socketPath).toBe(`${tmpDirPath}/vscode-ipc-aaa-1.sock`)
+      // Failed sockets should be removed from the entries.
+      expect((manager as any).entries.has(`${tmpDirPath}/vscode-ipc-aaa-2.sock`)).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
Fixes #5709

`readSocketPath` is now replaced by `VscodeSocketResolver` which will prefer editor sessions that match the files being opened.

How it works:
- Every newly created editor session now registers not just its socket path but also workspace data associated with the session, most notably the folders associated with the workspace. This data is encoded as JSON and appended to `vscode-ipc`.
- On CLI file open:
  - Read `vscode-ipc`
  - Return the first active socket, in order of "relevance". An editor session is more relevant if 1) one of the files being opened starts with one of the folders of the workspace, and otherwise if 2) the session was more recently registered to `vscode-ipc`
    - If there were any sockets that failed to connect, we write back to `vscode-ipc` with those sockets deleted. This also serves as a mechansim to prevent the file from growing unbounded.

Notes:
- We use a concatenation of newline-delimited JSON strings instead of a JSON array so we can simply append when registering an IPC socket. With pure JSON we'd have to read then write, which could introduce consistency issues.
- If there are no path matches, we fall back to most-recently created session. This matches VSCode behavior.

Future improvements:
- VSCode prefers workspace with more specific paths (i.e. `/foo/bar/` beats `/foo/` given `/foo/bar/baz.txt`). This was left out, but should not be too hard to add.


