### PR TITLE
Clipboard support

### DIFF
--- a/patches/clipboard.diff
+++ b/patches/clipboard.diff
@@ -1,0 +1,76 @@
+Index: code-server/lib/vscode/src/vs/workbench/api/browser/mainThreadCLICommands.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/workbench/api/browser/mainThreadCLICommands.ts
++++ code-server/lib/vscode/src/vs/workbench/api/browser/mainThreadCLICommands.ts
+@@ -8,6 +8,7 @@ import { isWeb } from 'vs/base/common/pl
+ import { isString } from 'vs/base/common/types';
+ import { URI, UriComponents } from 'vs/base/common/uri';
+ import { localize } from 'vs/nls';
++import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
+ import { CommandsRegistry, ICommandService } from 'vs/platform/commands/common/commands';
+ import { IExtensionGalleryService, IExtensionManagementService } from 'vs/platform/extensionManagement/common/extensionManagement';
+ import { ExtensionManagementCLI } from 'vs/platform/extensionManagement/common/extensionManagementCLI';
+@@ -90,6 +91,11 @@ CommandsRegistry.registerCommand('_remot
+ 	return lines.join('\n');
+ });
+ 
++CommandsRegistry.registerCommand('_remoteCLI.setClipboard', function (accessor: ServicesAccessor, content: string) {
++	const clipboardService = accessor.get(IClipboardService);
++	clipboardService.writeText(content);
++})
++
+ class RemoteExtensionManagementCLI extends ExtensionManagementCLI {
+ 
+ 	private _location: string | undefined;
+Index: code-server/lib/vscode/src/vs/workbench/api/node/extHostCLIServer.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/workbench/api/node/extHostCLIServer.ts
++++ code-server/lib/vscode/src/vs/workbench/api/node/extHostCLIServer.ts
+@@ -43,7 +43,12 @@ export interface ExtensionManagementPipe
+ 	force?: boolean;
+ }
+ 
+-export type PipeCommand = OpenCommandPipeArgs | StatusPipeArgs | OpenExternalCommandPipeArgs | ExtensionManagementPipeArgs;
++export interface ClipboardPipeArgs {
++	type: 'clipboard';
++	content: string;
++}
++
++export type PipeCommand = OpenCommandPipeArgs | StatusPipeArgs | OpenExternalCommandPipeArgs | ExtensionManagementPipeArgs | ClipboardPipeArgs;
+ 
+ export interface ICommandsExecuter {
+ 	executeCommand<T>(id: string, ...args: any[]): Promise<T>;
+@@ -105,6 +110,9 @@ export class CLIServerBase {
+ 					case 'extensionManagement':
+ 						returnObj = await this.manageExtensions(data);
+ 						break;
++					case 'clipboard':
++						returnObj = await this.clipboard(data);
++						break;
+ 					default:
+ 						sendResponse(404, `Unknown message type: ${data.type}`);
+ 						break;
+@@ -174,6 +182,10 @@ export class CLIServerBase {
+ 		return await this._commands.executeCommand('_remoteCLI.getSystemStatus');
+ 	}
+ 
++	private async clipboard(data: ClipboardPipeArgs) {
++		return await this._commands.executeCommand('_remoteCLI.setClipboard', data.content);
++	}
++
+ 	dispose(): void {
+ 		this._server.close();
+ 
+Index: code-server/lib/vscode/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
++++ code-server/lib/vscode/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
+@@ -91,7 +91,7 @@ class RemoteTerminalBackend extends Base
+ 			}
+ 		});
+ 
+-		const allowedCommands = ['_remoteCLI.openExternal', '_remoteCLI.windowOpen', '_remoteCLI.getSystemStatus', '_remoteCLI.manageExtensions'];
++		const allowedCommands = ['_remoteCLI.openExternal', '_remoteCLI.windowOpen', '_remoteCLI.getSystemStatus', '_remoteCLI.manageExtensions', '_remoteCLI.setClipboard'];
+ 		this._remoteTerminalChannel.onExecuteCommand(async e => {
+ 			// Ensure this request for for this window
+ 			const pty = this._ptys.get(e.persistentProcessId);

--- a/patches/clipboard.diff
+++ b/patches/clipboard.diff
@@ -74,3 +74,63 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/terminal/browser/remoteTe
  		this._remoteTerminalChannel.onExecuteCommand(async e => {
  			// Ensure this request for for this window
  			const pty = this._ptys.get(e.persistentProcessId);
+Index: code-server/lib/vscode/src/vs/platform/environment/common/argv.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/platform/environment/common/argv.ts
++++ code-server/lib/vscode/src/vs/platform/environment/common/argv.ts
+@@ -112,6 +112,7 @@ export interface NativeParsedArgs {
+ 	'profile-temp'?: boolean;
+ 
+ 	'enable-coi'?: boolean;
++	'clipboard'?: boolean;
+ 
+ 	// chromium command line args: https://electronjs.org/docs/all#supported-chrome-command-line-switches
+ 	'no-proxy-server'?: boolean;
+Index: code-server/lib/vscode/src/vs/platform/environment/node/argv.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/platform/environment/node/argv.ts
++++ code-server/lib/vscode/src/vs/platform/environment/node/argv.ts
+@@ -79,6 +79,7 @@ export const OPTIONS: OptionDescriptions
+ 	'user-data-dir': { type: 'string', cat: 'o', args: 'dir', description: localize('userDataDir', "Specifies the directory that user data is kept in. Can be used to open multiple distinct instances of Code.") },
+ 	'profile': { type: 'string', 'cat': 'o', args: 'profileName', description: localize('profileName', "Opens the provided folder or workspace with the given profile and associates the profile with the workspace. If the profile does not exist, a new empty one is created. A folder or workspace must be provided for the profile to take effect.") },
+ 	'help': { type: 'boolean', cat: 'o', alias: 'h', description: localize('help', "Print usage.") },
++	'clipboard': { type: 'boolean', cat: 'o', alias: 'c', description: localize('clipboard', "copies the STDIN to the clipboard") },
+ 
+ 	'extensions-dir': { type: 'string', deprecates: ['extensionHomePath'], cat: 'e', args: 'dir', description: localize('extensionHomePath', "Set the root path for extensions.") },
+ 	'extensions-download-dir': { type: 'string' },
+Index: code-server/lib/vscode/src/vs/server/node/server.cli.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/server/node/server.cli.ts
++++ code-server/lib/vscode/src/vs/server/node/server.cli.ts
+@@ -74,6 +74,7 @@ const isSupportedForPipe = (optionId: ke
+ 		case 'verbose':
+ 		case 'remote':
+ 		case 'locate-shell-integration-path':
++		case 'clipboard':
+ 			return true;
+ 		default:
+ 			return false;
+@@ -274,6 +275,23 @@ export async function main(desc: Product
+ 			_cp.spawn(cliCommand, newCommandline, { cwd: cliCwd, env, stdio: ['inherit'] });
+ 		}
+ 	} else {
++		if (parsedArgs.clipboard) {
++			if(!hasStdinWithoutTty()) {
++				console.error("stdin has a tty.");
++				return;
++			}
++			const fs = require("fs");
++			const stdinBuffer = fs.readFileSync(0); // STDIN_FILENO = 0
++			const clipboardContent = stdinBuffer.toString();
++			sendToPipe({
++				type: 'clipboard',
++				content: clipboardContent
++			}, verbose).catch(e => {
++				console.error('Error when requesting status:', e);
++			});
++			return;
++		}
++
+ 		if (parsedArgs.status) {
+ 			sendToPipe({
+ 				type: 'status'

--- a/patches/series
+++ b/patches/series
@@ -19,3 +19,4 @@ telemetry.diff
 display-language.diff
 cli-window-open.diff
 getting-started.diff
+clipboard.diff


### PR DESCRIPTION
Fixes #6175

You can try with a dev build and a patched code-server cli script:

```bash
#!/usr/bin/env sh
#
# Copyright (c) Microsoft Corporation. All rights reserved.
#
# PATCH to DEV path
VSROOT=/home/coder/dev/code-server/lib/vscode
ROOT="$(dirname "$(dirname "$VSROOT")")"

APP_NAME="code-server"
VERSION="1.77.3"
COMMIT="704ed70d4fd1c6bd6342c436f1ede30d1cff4710"
EXEC_NAME="code-server"
CLI_SCRIPT="$VSROOT/out/server-cli.js"
"${NODE_EXEC_PATH:-$ROOT/lib/node}" "$CLI_SCRIPT" "$APP_NAME" "$VERSION" "$COMMIT" "$EXEC_NAME" "$@"
```

and use it like this:

```bash
echo -n my clipboard text | ./code-server --clipboard
```

If it makes like this, it would be cool to have it in code-server already.

Nonetheless, I think this addition makes sense in all vscode based applications, so I will try to create an issue and PR on the vscode repo.
Would be nice to read your thoughts.