### PR TITLE
Update to 1.78.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660639432,
-        "narHash": "sha256-2WDiboOCfB0LhvnDVMXOAr8ZLDfm3WdO54CkoDPwN1A=",
+        "lastModified": 1683594133,
+        "narHash": "sha256-iUhLhEAgOCnexSGDsYT2ouydis09uDoNzM7UC685XGE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c6409e965a6c883677be7b9d87a95fab6c3472e",
+        "rev": "8d447c5626cfefb9b129d5b30103344377fe09bc",
         "type": "github"
       },
       "original": {
@@ -33,6 +36,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -12,11 +12,11 @@
         in {
           devShells.default = pkgs.mkShell {
             nativeBuildInputs = with pkgs; [
-              nodejs yarn' python pkg-config git rsync jq moreutils quilt bats
+              nodejs yarn' python3 pkg-config git rsync jq moreutils quilt bats
             ];
             buildInputs = with pkgs; (lib.optionals (!stdenv.isDarwin) [ libsecret ]
                           ++ (with xorg; [ libX11 libxkbfile ])
-                          ++ lib.optionals stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [ 
+                          ++ lib.optionals stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
                             AppKit Cocoa CoreServices Security xcbuild
                           ]));
           };

--- a/patches/base-path.diff
+++ b/patches/base-path.diff
@@ -10,7 +10,7 @@ Index: code-server/lib/vscode/src/vs/base/common/network.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/base/common/network.ts
 +++ code-server/lib/vscode/src/vs/base/common/network.ts
-@@ -166,7 +166,9 @@ class RemoteAuthoritiesImpl {
+@@ -167,7 +167,9 @@ class RemoteAuthoritiesImpl {
  		return URI.from({
  			scheme: platform.isWeb ? this._preferredWebSchema : Schemas.vscodeRemoteResource,
  			authority: `${host}:${port}`,
@@ -136,24 +136,20 @@ Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
  		if (!remoteAuthority) {
  			return serveError(req, res, 400, `Bad request.`);
  		}
-@@ -298,6 +297,8 @@ export class WebClientServer {
+@@ -298,8 +297,12 @@ export class WebClientServer {
  			scopes: [['user:email'], ['repo']]
  		} : undefined;
  
 +		const base = relativeRoot(getOriginalUrl(req))
 +		const vscodeBase = relativePath(getOriginalUrl(req))
- 
- 		const workbenchWebConfiguration = {
- 			remoteAuthority,
-@@ -309,6 +310,7 @@ export class WebClientServer {
- 			workspaceUri: resolveWorkspaceURI(this._environmentService.args['default-workspace']),
- 			productConfiguration: <Partial<IProductConfiguration>>{
- 				codeServerVersion: this._productService.codeServerVersion,
-+				rootEndpoint: base,
- 				embedderIdentifier: 'server-distro',
- 				extensionsGallery: this._webExtensionResourceUrlTemplate ? {
- 					...this._productService.extensionsGallery,
-@@ -326,8 +328,10 @@ export class WebClientServer {
++
+ 		const productConfiguration = <Partial<IProductConfiguration>>{
+ 			codeServerVersion: this._productService.codeServerVersion,
++			rootEndpoint: base,
+ 			embedderIdentifier: 'server-distro',
+ 			extensionsGallery: this._webExtensionResourceUrlTemplate ? {
+ 				...this._productService.extensionsGallery,
+@@ -334,11 +337,12 @@ export class WebClientServer {
  		const values: { [key: string]: string } = {
  			WORKBENCH_WEB_CONFIGURATION: asJSON(workbenchWebConfiguration),
  			WORKBENCH_AUTH_SESSION: authSessionInfo ? asJSON(authSessionInfo) : '',
@@ -165,8 +161,11 @@ Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
 +			VS_BASE: vscodeBase,
  		};
  
- 
-@@ -344,7 +348,7 @@ export class WebClientServer {
+-
+ 		let data;
+ 		try {
+ 			const workbenchTemplate = (await fsp.readFile(filePath)).toString();
+@@ -352,7 +356,7 @@ export class WebClientServer {
  			'default-src \'self\';',
  			'img-src \'self\' https: data: blob:;',
  			'media-src \'self\';',
@@ -175,7 +174,7 @@ Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
  			'child-src \'self\';',
  			`frame-src 'self' https://*.vscode-cdn.net data:;`,
  			'worker-src \'self\' data: blob:;',
-@@ -417,3 +421,70 @@ export class WebClientServer {
+@@ -425,3 +429,70 @@ export class WebClientServer {
  		return void res.end(data);
  	}
  }

--- a/patches/cli-window-open.diff
+++ b/patches/cli-window-open.diff
@@ -17,7 +17,7 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/terminal/browser/remoteTe
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
 +++ code-server/lib/vscode/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
-@@ -100,10 +100,14 @@ class RemoteTerminalBackend extends Base
+@@ -97,10 +97,14 @@ class RemoteTerminalBackend extends Base
  			}
  			const reqId = e.reqId;
  			const commandId = e.commandId;

--- a/patches/disable-downloads.diff
+++ b/patches/disable-downloads.diff
@@ -78,7 +78,7 @@ Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/server/node/webClientServer.ts
 +++ code-server/lib/vscode/src/vs/server/node/webClientServer.ts
-@@ -304,6 +304,7 @@ export class WebClientServer {
+@@ -325,6 +325,7 @@ export class WebClientServer {
  			remoteAuthority,
  			webviewEndpoint: vscodeBase + this._staticRoute + '/out/vs/workbench/contrib/webview/browser/pre',
  			userDataPath: this._environmentService.userDataPath,

--- a/patches/display-language.diff
+++ b/patches/display-language.diff
@@ -211,23 +211,23 @@ Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
  import { CharCode } from 'vs/base/common/charCode';
  import { getRemoteServerRootPath } from 'vs/platform/remote/common/remoteHosts';
  
-@@ -299,6 +300,8 @@ export class WebClientServer {
+@@ -337,6 +338,8 @@ export class WebClientServer {
+ 			callbackRoute: this._callbackRoute
+ 		};
  
- 		const base = relativeRoot(getOriginalUrl(req))
- 		const vscodeBase = relativePath(getOriginalUrl(req))
 +		const locale = this._environmentService.args.locale || await getLocaleFromConfig(this._environmentService.argvResource.fsPath);
 +		const nlsConfiguration = await getNLSConfiguration(locale, this._environmentService.userDataPath)
- 
- 		const workbenchWebConfiguration = {
- 			remoteAuthority,
-@@ -336,6 +339,7 @@ export class WebClientServer {
+ 		const nlsBaseUrl = this._productService.extensionsGallery?.nlsBaseUrl;
+ 		const values: { [key: string]: string } = {
+ 			WORKBENCH_WEB_CONFIGURATION: asJSON(workbenchWebConfiguration),
+@@ -345,6 +348,7 @@ export class WebClientServer {
  			WORKBENCH_NLS_BASE_URL: vscodeBase + (nlsBaseUrl ? `${nlsBaseUrl}${!nlsBaseUrl.endsWith('/') ? '/' : ''}${this._productService.commit}/${this._productService.version}/` : ''),
  			BASE: base,
  			VS_BASE: vscodeBase,
 +			NLS_CONFIGURATION: asJSON(nlsConfiguration),
  		};
  
- 
+ 		let data;
 Index: code-server/lib/vscode/src/vs/server/node/serverEnvironmentService.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/server/node/serverEnvironmentService.ts
@@ -261,9 +261,9 @@ Index: code-server/lib/vscode/src/vs/workbench/workbench.web.main.ts
  import 'vs/workbench/services/path/browser/pathService';
  import 'vs/workbench/services/themes/browser/browserHostColorSchemeService';
  import 'vs/workbench/services/encryption/browser/encryptionService';
-@@ -119,8 +119,9 @@ import 'vs/workbench/contrib/logs/browse
- // Explorer
- import 'vs/workbench/contrib/files/browser/files.web.contribution';
+@@ -116,8 +116,9 @@ registerSingleton(ILanguagePackService,
+ // Logs
+ import 'vs/workbench/contrib/logs/browser/logs.contribution';
  
 -// Localization
 -import 'vs/workbench/contrib/localization/browser/localization.contribution';

--- a/patches/getting-started.diff
+++ b/patches/getting-started.diff
@@ -19,7 +19,7 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/welcomeGettingStarted/bro
  import { OpenFolderViaWorkspaceAction } from 'vs/workbench/browser/actions/workspaceActions';
  import { OpenRecentAction } from 'vs/workbench/browser/actions/windowActions';
  import { Toggle } from 'vs/base/browser/ui/toggle/toggle';
-@@ -796,6 +796,72 @@ export class GettingStartedPage extends
+@@ -817,6 +817,72 @@ export class GettingStartedPage extends
  			$('p.subtitle.description', {}, localize({ key: 'gettingStarted.editingEvolved', comment: ['Shown as subtitle on the Welcome page.'] }, "Editing evolved"))
  		);
  
@@ -92,7 +92,7 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/welcomeGettingStarted/bro
  		const leftColumn = $('.categories-column.categories-column-left', {},);
  		const rightColumn = $('.categories-column.categories-column-right', {},);
  
-@@ -814,13 +880,23 @@ export class GettingStartedPage extends
+@@ -835,13 +901,23 @@ export class GettingStartedPage extends
  		const layoutLists = () => {
  			if (gettingStartedList.itemCount) {
  				this.container.classList.remove('noWalkthroughs');
@@ -120,7 +120,7 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/welcomeGettingStarted/bro
  			}
  			setTimeout(() => this.categoriesPageScrollbar?.scanDomNode(), 50);
  		};
-@@ -828,13 +904,23 @@ export class GettingStartedPage extends
+@@ -849,13 +925,23 @@ export class GettingStartedPage extends
  		const layoutFeaturedExtension = () => {
  			if (featuredExtensionList.itemCount) {
  				this.container.classList.remove('noExtensions');
@@ -238,7 +238,7 @@ Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/server/node/webClientServer.ts
 +++ code-server/lib/vscode/src/vs/server/node/webClientServer.ts
-@@ -308,6 +308,7 @@ export class WebClientServer {
+@@ -328,6 +328,7 @@ export class WebClientServer {
  			webviewEndpoint: vscodeBase + this._staticRoute + '/out/vs/workbench/contrib/webview/browser/pre',
  			userDataPath: this._environmentService.userDataPath,
  			isEnabledFileDownloads: !this._environmentService.args['disable-file-downloads'],

--- a/patches/integration.diff
+++ b/patches/integration.diff
@@ -95,7 +95,7 @@ Index: code-server/lib/vscode/src/vs/base/common/processes.ts
 --- code-server.orig/lib/vscode/src/vs/base/common/processes.ts
 +++ code-server/lib/vscode/src/vs/base/common/processes.ts
 @@ -111,6 +111,8 @@ export function sanitizeProcessEnvironme
- 		/^VSCODE_(?!(PORTABLE|SHELL_LOGIN)).+$/,
+ 		/^VSCODE_(?!(PORTABLE|SHELL_LOGIN|ENV_REPLACE|ENV_APPEND|ENV_PREPEND)).+$/,
  		/^SNAP(|_.*)$/,
  		/^GDK_PIXBUF_.+$/,
 +		/^CODE_SERVER_.+$/,
@@ -107,7 +107,7 @@ Index: code-server/lib/vscode/src/vs/workbench/browser/parts/dialogs/dialogHandl
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
 +++ code-server/lib/vscode/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
-@@ -76,8 +76,11 @@ export class BrowserDialogHandler extend
+@@ -77,8 +77,11 @@ export class BrowserDialogHandler extend
  
  	async about(): Promise<void> {
  		const detailString = (useAgo: boolean): string => {
@@ -184,7 +184,7 @@ Index: code-server/lib/vscode/src/vs/workbench/browser/web.main.ts
  import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
  import { IProgressService } from 'vs/platform/progress/common/progress';
  import { DelayedLogChannel } from 'vs/workbench/services/output/common/delayedLogChannel';
-@@ -119,6 +120,9 @@ export class BrowserMain extends Disposa
+@@ -123,6 +124,9 @@ export class BrowserMain extends Disposa
  		// Startup
  		const instantiationService = workbench.startup();
  
@@ -264,11 +264,11 @@ Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/server/node/webClientServer.ts
 +++ code-server/lib/vscode/src/vs/server/node/webClientServer.ts
-@@ -308,6 +308,7 @@ export class WebClientServer {
- 			folderUri: resolveWorkspaceURI(this._environmentService.args['default-folder']),
- 			workspaceUri: resolveWorkspaceURI(this._environmentService.args['default-workspace']),
- 			productConfiguration: <Partial<IProductConfiguration>>{
-+				codeServerVersion: this._productService.codeServerVersion,
- 				embedderIdentifier: 'server-distro',
- 				extensionsGallery: this._webExtensionResourceUrlTemplate ? {
- 					...this._productService.extensionsGallery,
+@@ -299,6 +299,7 @@ export class WebClientServer {
+ 		} : undefined;
+ 
+ 		const productConfiguration = <Partial<IProductConfiguration>>{
++			codeServerVersion: this._productService.codeServerVersion,
+ 			embedderIdentifier: 'server-distro',
+ 			extensionsGallery: this._webExtensionResourceUrlTemplate ? {
+ 				...this._productService.extensionsGallery,

--- a/patches/local-storage.diff
+++ b/patches/local-storage.diff
@@ -20,7 +20,7 @@ Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/server/node/webClientServer.ts
 +++ code-server/lib/vscode/src/vs/server/node/webClientServer.ts
-@@ -303,6 +303,7 @@ export class WebClientServer {
+@@ -320,6 +320,7 @@ export class WebClientServer {
  		const workbenchWebConfiguration = {
  			remoteAuthority,
  			webviewEndpoint: vscodeBase + this._staticRoute + '/out/vs/workbench/contrib/webview/browser/pre',

--- a/patches/logout.diff
+++ b/patches/logout.diff
@@ -40,14 +40,14 @@ Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/server/node/webClientServer.ts
 +++ code-server/lib/vscode/src/vs/server/node/webClientServer.ts
-@@ -313,6 +313,7 @@ export class WebClientServer {
- 				codeServerVersion: this._productService.codeServerVersion,
- 				rootEndpoint: base,
- 				updateEndpoint: !this._environmentService.args['disable-update-check'] ? base + '/update/check' : undefined,
-+				logoutEndpoint: this._environmentService.args['auth'] && this._environmentService.args['auth'] !== "none" ? base + '/logout' : undefined,
- 				embedderIdentifier: 'server-distro',
- 				extensionsGallery: this._productService.extensionsGallery,
- 			},
+@@ -304,6 +304,7 @@ export class WebClientServer {
+ 			codeServerVersion: this._productService.codeServerVersion,
+ 			rootEndpoint: base,
+ 			updateEndpoint: !this._environmentService.args['disable-update-check'] ? base + '/update/check' : undefined,
++			logoutEndpoint: this._environmentService.args['auth'] && this._environmentService.args['auth'] !== "none" ? base + '/logout' : undefined,
+ 			embedderIdentifier: 'server-distro',
+ 			extensionsGallery: this._productService.extensionsGallery,
+ 		};
 Index: code-server/lib/vscode/src/vs/workbench/browser/client.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/browser/client.ts

--- a/patches/marketplace.diff
+++ b/patches/marketplace.diff
@@ -49,22 +49,22 @@ Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
  	}
  
  	/**
-@@ -312,14 +312,7 @@ export class WebClientServer {
- 				codeServerVersion: this._productService.codeServerVersion,
- 				rootEndpoint: base,
- 				embedderIdentifier: 'server-distro',
--				extensionsGallery: this._webExtensionResourceUrlTemplate ? {
--					...this._productService.extensionsGallery,
--					'resourceUrlTemplate': this._webExtensionResourceUrlTemplate.with({
--						scheme: 'http',
--						authority: remoteAuthority,
--						path: `${this._webExtensionRoute}/${this._webExtensionResourceUrlTemplate.authority}${this._webExtensionResourceUrlTemplate.path}`
--					}).toString(true)
--				} : undefined
-+				extensionsGallery: this._productService.extensionsGallery,
- 			},
- 			callbackRoute: this._callbackRoute
+@@ -304,14 +304,7 @@ export class WebClientServer {
+ 			codeServerVersion: this._productService.codeServerVersion,
+ 			rootEndpoint: base,
+ 			embedderIdentifier: 'server-distro',
+-			extensionsGallery: this._webExtensionResourceUrlTemplate ? {
+-				...this._productService.extensionsGallery,
+-				'resourceUrlTemplate': this._webExtensionResourceUrlTemplate.with({
+-					scheme: 'http',
+-					authority: remoteAuthority,
+-					path: `${this._webExtensionRoute}/${this._webExtensionResourceUrlTemplate.authority}${this._webExtensionResourceUrlTemplate.path}`
+-				}).toString(true)
+-			} : undefined
++			extensionsGallery: this._productService.extensionsGallery,
  		};
+ 
+ 		if (!this._environmentService.isBuilt) {
 Index: code-server/lib/vscode/src/vs/platform/extensionResourceLoader/common/extensionResourceLoader.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/platform/extensionResourceLoader/common/extensionResourceLoader.ts

--- a/patches/proxy-uri.diff
+++ b/patches/proxy-uri.diff
@@ -80,14 +80,14 @@ Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/server/node/webClientServer.ts
 +++ code-server/lib/vscode/src/vs/server/node/webClientServer.ts
-@@ -314,6 +314,7 @@ export class WebClientServer {
- 				rootEndpoint: base,
- 				updateEndpoint: !this._environmentService.args['disable-update-check'] ? base + '/update/check' : undefined,
- 				logoutEndpoint: this._environmentService.args['auth'] && this._environmentService.args['auth'] !== "none" ? base + '/logout' : undefined,
-+				proxyEndpointTemplate: process.env.VSCODE_PROXY_URI ?? base + '/proxy/{{port}}/',
- 				embedderIdentifier: 'server-distro',
- 				extensionsGallery: this._productService.extensionsGallery,
- 			},
+@@ -305,6 +305,7 @@ export class WebClientServer {
+ 			rootEndpoint: base,
+ 			updateEndpoint: !this._environmentService.args['disable-update-check'] ? base + '/update/check' : undefined,
+ 			logoutEndpoint: this._environmentService.args['auth'] && this._environmentService.args['auth'] !== "none" ? base + '/logout' : undefined,
++			proxyEndpointTemplate: process.env.VSCODE_PROXY_URI ?? base + '/proxy/{{port}}/',
+ 			embedderIdentifier: 'server-distro',
+ 			extensionsGallery: this._productService.extensionsGallery,
+ 		};
 Index: code-server/lib/vscode/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts

--- a/patches/service-worker.diff
+++ b/patches/service-worker.diff
@@ -54,14 +54,14 @@ Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/server/node/webClientServer.ts
 +++ code-server/lib/vscode/src/vs/server/node/webClientServer.ts
-@@ -316,6 +316,10 @@ export class WebClientServer {
- 				updateEndpoint: !this._environmentService.args['disable-update-check'] ? base + '/update/check' : undefined,
- 				logoutEndpoint: this._environmentService.args['auth'] && this._environmentService.args['auth'] !== "none" ? base + '/logout' : undefined,
- 				proxyEndpointTemplate: process.env.VSCODE_PROXY_URI ?? base + '/proxy/{{port}}/',
-+				serviceWorker: {
-+					scope: vscodeBase + '/',
-+					path: base + '/_static/out/browser/serviceWorker.js',
-+				},
- 				embedderIdentifier: 'server-distro',
- 				extensionsGallery: this._productService.extensionsGallery,
- 			},
+@@ -306,6 +306,10 @@ export class WebClientServer {
+ 			updateEndpoint: !this._environmentService.args['disable-update-check'] ? base + '/update/check' : undefined,
+ 			logoutEndpoint: this._environmentService.args['auth'] && this._environmentService.args['auth'] !== "none" ? base + '/logout' : undefined,
+ 			proxyEndpointTemplate: process.env.VSCODE_PROXY_URI ?? base + '/proxy/{{port}}/',
++			serviceWorker: {
++				scope: vscodeBase + '/',
++				path: base + '/_static/out/browser/serviceWorker.js',
++			},
+ 			embedderIdentifier: 'server-distro',
+ 			extensionsGallery: this._productService.extensionsGallery,
+ 		};

--- a/patches/sourcemaps.diff
+++ b/patches/sourcemaps.diff
@@ -10,7 +10,7 @@ Index: code-server/lib/vscode/build/gulpfile.reh.js
 ===================================================================
 --- code-server.orig/lib/vscode/build/gulpfile.reh.js
 +++ code-server/lib/vscode/build/gulpfile.reh.js
-@@ -191,8 +191,7 @@ function packageTask(type, platform, arc
+@@ -197,8 +197,7 @@ function packageTask(type, platform, arc
  
  		const src = gulp.src(sourceFolderName + '/**', { base: '.' })
  			.pipe(rename(function (path) { path.dirname = path.dirname.replace(new RegExp('^' + sourceFolderName), 'out'); }))
@@ -20,7 +20,7 @@ Index: code-server/lib/vscode/build/gulpfile.reh.js
  
  		const workspaceExtensionPoints = ['debuggers', 'jsonValidation'];
  		const isUIExtension = (manifest) => {
-@@ -231,9 +230,9 @@ function packageTask(type, platform, arc
+@@ -237,9 +236,9 @@ function packageTask(type, platform, arc
  			.map(name => `.build/extensions/${name}/**`);
  
  		const extensions = gulp.src(extensionPaths, { base: '.build', dot: true });
@@ -32,7 +32,7 @@ Index: code-server/lib/vscode/build/gulpfile.reh.js
  
  		let version = packageJson.version;
  		const quality = product.quality;
-@@ -388,7 +387,7 @@ function tweakProductForServerWeb(produc
+@@ -394,7 +393,7 @@ function tweakProductForServerWeb(produc
  	const minifyTask = task.define(`minify-vscode-${type}`, task.series(
  		optimizeTask,
  		util.rimraf(`out-vscode-${type}-min`),

--- a/patches/telemetry.diff
+++ b/patches/telemetry.diff
@@ -94,11 +94,11 @@ Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/server/node/webClientServer.ts
 +++ code-server/lib/vscode/src/vs/server/node/webClientServer.ts
-@@ -321,6 +321,7 @@ export class WebClientServer {
- 					scope: vscodeBase + '/',
- 					path: base + '/_static/out/browser/serviceWorker.js',
- 				},
-+				enableTelemetry: this._productService.enableTelemetry,
- 				embedderIdentifier: 'server-distro',
- 				extensionsGallery: this._productService.extensionsGallery,
+@@ -310,6 +310,7 @@ export class WebClientServer {
+ 				scope: vscodeBase + '/',
+ 				path: base + '/_static/out/browser/serviceWorker.js',
  			},
++			enableTelemetry: this._productService.enableTelemetry,
+ 			embedderIdentifier: 'server-distro',
+ 			extensionsGallery: this._productService.extensionsGallery,
+ 		};

--- a/patches/update-check.diff
+++ b/patches/update-check.diff
@@ -105,14 +105,14 @@ Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/server/node/webClientServer.ts
 +++ code-server/lib/vscode/src/vs/server/node/webClientServer.ts
-@@ -312,6 +312,7 @@ export class WebClientServer {
- 			productConfiguration: <Partial<IProductConfiguration>>{
- 				codeServerVersion: this._productService.codeServerVersion,
- 				rootEndpoint: base,
-+				updateEndpoint: !this._environmentService.args['disable-update-check'] ? base + '/update/check' : undefined,
- 				embedderIdentifier: 'server-distro',
- 				extensionsGallery: this._productService.extensionsGallery,
- 			},
+@@ -303,6 +303,7 @@ export class WebClientServer {
+ 		const productConfiguration = <Partial<IProductConfiguration>>{
+ 			codeServerVersion: this._productService.codeServerVersion,
+ 			rootEndpoint: base,
++			updateEndpoint: !this._environmentService.args['disable-update-check'] ? base + '/update/check' : undefined,
+ 			embedderIdentifier: 'server-distro',
+ 			extensionsGallery: this._productService.extensionsGallery,
+ 		};
 Index: code-server/lib/vscode/src/vs/server/node/serverEnvironmentService.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/server/node/serverEnvironmentService.ts

--- a/patches/webview.diff
+++ b/patches/webview.diff
@@ -54,7 +54,7 @@ Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/server/node/webClientServer.ts
 +++ code-server/lib/vscode/src/vs/server/node/webClientServer.ts
-@@ -302,6 +302,7 @@ export class WebClientServer {
+@@ -316,6 +316,7 @@ export class WebClientServer {
  
  		const workbenchWebConfiguration = {
  			remoteAuthority,
@@ -70,12 +70,12 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/webview/browser/pre/index
  	<meta charset="UTF-8">
  
  	<meta http-equiv="Content-Security-Policy"
--		content="default-src 'none'; script-src 'sha256-4A7BC3A+gc8e1t5I0rfDNtBiGlA0/GTojKdfdDHAWYw=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
-+		content="default-src 'none'; script-src 'sha256-8I6aYsGyWES1C043+SeEOyeZlC0Y0HN5WevEDh97c1Y=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+-		content="default-src 'none'; script-src 'sha256-N4YFn5ze5crjPqMK/opogKs7bSGWtf3lmjV/3LfbSOs=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
++		content="default-src 'none'; script-src 'sha256-B5FRTRmagxqZ2yiS/ip5EgFZJPHAF0G0O3NgwgN6hhg=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
  
  	<!-- Disable pinch zooming -->
  	<meta name="viewport"
-@@ -323,6 +323,12 @@
+@@ -334,6 +334,12 @@
  
  				const hostname = location.hostname;
  
@@ -92,7 +92,7 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/webview/browser/pre/index
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
 +++ code-server/lib/vscode/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
-@@ -322,6 +322,12 @@
+@@ -333,6 +333,12 @@
  
  				const hostname = location.hostname;
  


### PR DESCRIPTION
No changes needed in the patches other than moving some lines around and updating the CSP hash as usual.

The flake had to be updated as it was using Node 16.16 and 16.17 is required at minimum now.  Also `python` seems to install Python 2 which is marked as deprecated so explicitly install `python3`.

Also had to update the environment variable used to provide the commit during build.

Closes #6190 
