### PR TITLE
Set session socket into environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ Code v99.99.999
 
 Code v1.79.2
 
+### Fixed
+
+- Fix being unable to launch multiple instances of code-server for different
+  users.
+
+### Added
+
+- `--session-socket` CLI flag to configure the location of the session socket.
+  By default it will be placed in `--user-data-dir`.
+
 ## [4.14.0](https://github.com/coder/code-server/releases/tag/v4.14.0) - 2023-06-16
 
 Code v1.79.2

--- a/patches/store-socket.diff
+++ b/patches/store-socket.diff
@@ -15,18 +15,16 @@ Index: code-server/lib/vscode/src/vs/workbench/api/node/extHostExtensionService.
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/api/node/extHostExtensionService.ts
 +++ code-server/lib/vscode/src/vs/workbench/api/node/extHostExtensionService.ts
-@@ -2,7 +2,9 @@
+@@ -2,7 +2,7 @@
   *  Copyright (c) Microsoft Corporation. All rights reserved.
   *  Licensed under the MIT License. See License.txt in the project root for license information.
   *--------------------------------------------------------------------------------------------*/
 -
-+import * as os from 'os';
 +import * as _http from 'http';
-+import * as path from 'vs/base/common/path';
  import * as performance from 'vs/base/common/performance';
  import { createApiFactoryAndRegisterActors } from 'vs/workbench/api/common/extHost.api.impl';
  import { RequireInterceptor } from 'vs/workbench/api/common/extHostRequireInterceptor';
-@@ -17,6 +19,7 @@ import { ExtensionRuntime } from 'vs/wor
+@@ -17,6 +17,7 @@ import { ExtensionRuntime } from 'vs/wor
  import { CLIServer } from 'vs/workbench/api/node/extHostCLIServer';
  import { realpathSync } from 'vs/base/node/extpath';
  import { ExtHostConsoleForwarder } from 'vs/workbench/api/node/extHostConsoleForwarder';
@@ -34,13 +32,14 @@ Index: code-server/lib/vscode/src/vs/workbench/api/node/extHostExtensionService.
  import { ExtHostDiskFileSystemProvider } from 'vs/workbench/api/node/extHostDiskFileSystemProvider';
  
  class NodeModuleRequireInterceptor extends RequireInterceptor {
-@@ -83,6 +86,52 @@ export class ExtHostExtensionService ext
+@@ -83,6 +84,52 @@ export class ExtHostExtensionService ext
  		await interceptor.install();
  		performance.mark('code/extHost/didInitAPI');
  
 +		(async () => {
 +			const socketPath = process.env['VSCODE_IPC_HOOK_CLI'];
-+			if (!socketPath) {
++			const codeServerSocketPath = process.env['CODE_SERVER_SESSION_SOCKET']
++			if (!socketPath || !codeServerSocketPath) {
 +				return;
 +			}
 +			const workspace = this._instaService.invokeFunction((accessor) => {
@@ -52,7 +51,6 @@ Index: code-server/lib/vscode/src/vs/workbench/api/node/extHostExtensionService.
 +				socketPath
 +			};
 +			const message = JSON.stringify({entry});
-+			const codeServerSocketPath = path.join(os.tmpdir(), 'code-server-ipc.sock');
 +			await new Promise<void>((resolve, reject) => {
 +				const opts: _http.RequestOptions = {
 +					path: '/add-session',
@@ -91,17 +89,15 @@ Index: code-server/lib/vscode/src/vs/workbench/api/node/extensionHostProcess.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/api/node/extensionHostProcess.ts
 +++ code-server/lib/vscode/src/vs/workbench/api/node/extensionHostProcess.ts
-@@ -3,6 +3,9 @@
+@@ -3,6 +3,7 @@
   *  Licensed under the MIT License. See License.txt in the project root for license information.
   *--------------------------------------------------------------------------------------------*/
  
-+import * as os from 'os';
 +import * as _http from 'http';
-+import * as path from 'vs/base/common/path';
  import * as nativeWatchdog from 'native-watchdog';
  import * as net from 'net';
  import * as minimist from 'minimist';
-@@ -400,7 +403,28 @@ async function startExtensionHostProcess
+@@ -400,7 +401,28 @@ async function startExtensionHostProcess
  	);
  
  	// rewrite onTerminate-function to be a proper shutdown
@@ -110,11 +106,11 @@ Index: code-server/lib/vscode/src/vs/workbench/api/node/extensionHostProcess.ts
 +		extensionHostMain.terminate(reason);
 +
 +		const socketPath = process.env['VSCODE_IPC_HOOK_CLI'];
-+		if (!socketPath) {
++		const codeServerSocketPath = process.env['CODE_SERVER_SESSION_SOCKET']
++		if (!socketPath || !codeServerSocketPath) {
 +			return;
 +		}
 +		const message = JSON.stringify({socketPath});
-+		const codeServerSocketPath = path.join(os.tmpdir(), 'code-server-ipc.sock');
 +		const opts: _http.RequestOptions = {
 +			path: '/delete-session',
 +			socketPath: codeServerSocketPath,

--- a/src/node/app.ts
+++ b/src/node/app.ts
@@ -9,7 +9,7 @@ import * as util from "../common/util"
 import { DefaultedArgs } from "./cli"
 import { disposer } from "./http"
 import { isNodeJSErrnoException } from "./util"
-import { DEFAULT_SOCKET_PATH, EditorSessionManager, makeEditorSessionManagerServer } from "./vscodeSocket"
+import { EditorSessionManager, makeEditorSessionManagerServer } from "./vscodeSocket"
 import { handleUpgrade } from "./wsRouter"
 
 type SocketOptions = { socket: string; "socket-mode"?: string }
@@ -88,7 +88,7 @@ export const createApp = async (args: DefaultedArgs): Promise<App> => {
   handleUpgrade(wsRouter, server)
 
   const editorSessionManager = new EditorSessionManager()
-  const editorSessionManagerServer = await makeEditorSessionManagerServer(DEFAULT_SOCKET_PATH, editorSessionManager)
+  const editorSessionManagerServer = await makeEditorSessionManagerServer(args["session-socket"], editorSessionManager)
   const disposeEditorSessionManagerServer = disposer(editorSessionManagerServer)
 
   const dispose = async () => {

--- a/src/node/entry.ts
+++ b/src/node/entry.ts
@@ -51,7 +51,7 @@ async function entry(): Promise<void> {
     return runCodeCli(args)
   }
 
-  const socketPath = await shouldOpenInExistingInstance(cliArgs)
+  const socketPath = await shouldOpenInExistingInstance(cliArgs, args["session-socket"])
   if (socketPath) {
     logger.debug("Trying to open in existing instance")
     return openInExistingInstance(args, socketPath)

--- a/src/node/vscodeSocket.ts
+++ b/src/node/vscodeSocket.ts
@@ -4,10 +4,7 @@ import * as http from "http"
 import * as path from "path"
 import { HttpCode } from "../common/http"
 import { listen } from "./app"
-import { canConnect, paths } from "./util"
-
-// Socket path of the daemonized code-server instance.
-export const DEFAULT_SOCKET_PATH = path.join(paths.data, `code-server-ipc.sock`)
+import { canConnect } from "./util"
 
 export interface EditorSessionEntry {
   workspace: {

--- a/test/e2e/terminal.test.ts
+++ b/test/e2e/terminal.test.ts
@@ -35,13 +35,19 @@ describe("Integrated Terminal", ["--disable-workspace-trust"], {}, () => {
     const tmpFolderPath = await tmpdir(testName)
     const tmpFile = path.join(tmpFolderPath, "test-file")
     await fs.writeFile(tmpFile, "test")
-    const fileName = path.basename(tmpFile)
 
     await codeServerPage.focusTerminal()
 
     await codeServerPage.page.keyboard.type(`code-server ${tmpFile}`)
     await codeServerPage.page.keyboard.press("Enter")
 
-    await codeServerPage.waitForTab(fileName)
+    await codeServerPage.waitForTab(path.basename(tmpFile))
+
+    const externalTmpFile = path.join(tmpFolderPath, "test-external-file")
+    await fs.writeFile(externalTmpFile, "foobar")
+
+    await codeServerPage.openFileExternally(externalTmpFile)
+
+    await codeServerPage.waitForTab(path.basename(externalTmpFile))
   })
 })

--- a/test/unit/node/cli.test.ts
+++ b/test/unit/node/cli.test.ts
@@ -516,7 +516,7 @@ describe("cli", () => {
 
     const args: UserProvidedArgs = {}
     args["reuse-window"] = true
-    await expect(shouldOpenInExistingInstance(args)).resolves.toStrictEqual(undefined)
+    await expect(shouldOpenInExistingInstance(args)).rejects.toThrow()
 
     const socketPath = path.join(tmpDirPath, "socket")
     const client = new EditorSessionManagerClient(DEFAULT_SOCKET_PATH)
@@ -551,7 +551,7 @@ describe("cli", () => {
 
     const args: UserProvidedArgs = {}
     args["new-window"] = true
-    await expect(shouldOpenInExistingInstance(args)).resolves.toStrictEqual(undefined)
+    await expect(shouldOpenInExistingInstance(args)).rejects.toThrow()
 
     const socketPath = path.join(tmpDirPath, "socket")
     const client = new EditorSessionManagerClient(DEFAULT_SOCKET_PATH)

--- a/test/unit/node/cli.test.ts
+++ b/test/unit/node/cli.test.ts
@@ -18,7 +18,6 @@ import {
 import { shouldSpawnCliProcess } from "../../../src/node/main"
 import { generatePassword, paths } from "../../../src/node/util"
 import {
-  DEFAULT_SOCKET_PATH,
   EditorSessionManager,
   EditorSessionManagerClient,
   makeEditorSessionManagerServer,
@@ -37,6 +36,7 @@ const defaults = {
   usingEnvHashedPassword: false,
   "extensions-dir": path.join(paths.data, "extensions"),
   "user-data-dir": paths.data,
+  "session-socket": path.join(paths.data, "code-server-ipc.sock"),
   _: [],
 }
 
@@ -103,6 +103,8 @@ describe("parser", () => {
 
           "--disable-getting-started-override",
 
+          ["--session-socket", "/tmp/override-code-server-ipc-socket"],
+
           ["--host", "0.0.0.0"],
           "4",
           "--",
@@ -136,6 +138,7 @@ describe("parser", () => {
       "welcome-text": "welcome to code",
       version: true,
       "bind-addr": "192.169.0.1:8080",
+      "session-socket": "/tmp/override-code-server-ipc-socket",
     })
   })
 
@@ -504,22 +507,23 @@ describe("cli", () => {
   it("should use existing if inside code-server", async () => {
     process.env.VSCODE_IPC_HOOK_CLI = "test"
     const args: UserProvidedArgs = {}
-    expect(await shouldOpenInExistingInstance(args)).toStrictEqual("test")
+    expect(await shouldOpenInExistingInstance(args, "")).toStrictEqual("test")
 
     args.port = 8081
     args._ = ["./file"]
-    expect(await shouldOpenInExistingInstance(args)).toStrictEqual("test")
+    expect(await shouldOpenInExistingInstance(args, "")).toStrictEqual("test")
   })
 
   it("should use existing if --reuse-window is set", async () => {
-    const server = await makeEditorSessionManagerServer(DEFAULT_SOCKET_PATH, new EditorSessionManager())
+    const sessionSocket = path.join(tmpDirPath, "session-socket")
+    const server = await makeEditorSessionManagerServer(sessionSocket, new EditorSessionManager())
 
     const args: UserProvidedArgs = {}
     args["reuse-window"] = true
-    await expect(shouldOpenInExistingInstance(args)).rejects.toThrow()
+    await expect(shouldOpenInExistingInstance(args, sessionSocket)).rejects.toThrow()
 
     const socketPath = path.join(tmpDirPath, "socket")
-    const client = new EditorSessionManagerClient(DEFAULT_SOCKET_PATH)
+    const client = new EditorSessionManagerClient(sessionSocket)
     await client.addSession({
       entry: {
         workspace: {
@@ -537,24 +541,25 @@ describe("cli", () => {
     })
     const vscodeSockets = listenOn(socketPath)
 
-    await expect(shouldOpenInExistingInstance(args)).resolves.toStrictEqual(socketPath)
+    await expect(shouldOpenInExistingInstance(args, sessionSocket)).resolves.toStrictEqual(socketPath)
 
     args.port = 8081
-    await expect(shouldOpenInExistingInstance(args)).resolves.toStrictEqual(socketPath)
+    await expect(shouldOpenInExistingInstance(args, sessionSocket)).resolves.toStrictEqual(socketPath)
 
     server.close()
     vscodeSockets.close()
   })
 
   it("should use existing if --new-window is set", async () => {
-    const server = await makeEditorSessionManagerServer(DEFAULT_SOCKET_PATH, new EditorSessionManager())
+    const sessionSocket = path.join(tmpDirPath, "session-socket")
+    const server = await makeEditorSessionManagerServer(sessionSocket, new EditorSessionManager())
 
     const args: UserProvidedArgs = {}
     args["new-window"] = true
-    await expect(shouldOpenInExistingInstance(args)).rejects.toThrow()
+    await expect(shouldOpenInExistingInstance(args, sessionSocket)).rejects.toThrow()
 
     const socketPath = path.join(tmpDirPath, "socket")
-    const client = new EditorSessionManagerClient(DEFAULT_SOCKET_PATH)
+    const client = new EditorSessionManagerClient(sessionSocket)
     await client.addSession({
       entry: {
         workspace: {
@@ -572,25 +577,26 @@ describe("cli", () => {
     })
     const vscodeSockets = listenOn(socketPath)
 
-    expect(await shouldOpenInExistingInstance(args)).toStrictEqual(socketPath)
+    expect(await shouldOpenInExistingInstance(args, sessionSocket)).toStrictEqual(socketPath)
 
     args.port = 8081
-    expect(await shouldOpenInExistingInstance(args)).toStrictEqual(socketPath)
+    expect(await shouldOpenInExistingInstance(args, sessionSocket)).toStrictEqual(socketPath)
 
     server.close()
     vscodeSockets.close()
   })
 
   it("should use existing if no unrelated flags are set, has positional, and socket is active", async () => {
-    const server = await makeEditorSessionManagerServer(DEFAULT_SOCKET_PATH, new EditorSessionManager())
+    const sessionSocket = path.join(tmpDirPath, "session-socket")
+    const server = await makeEditorSessionManagerServer(sessionSocket, new EditorSessionManager())
 
     const args: UserProvidedArgs = {}
-    expect(await shouldOpenInExistingInstance(args)).toStrictEqual(undefined)
+    expect(await shouldOpenInExistingInstance(args, sessionSocket)).toStrictEqual(undefined)
 
     args._ = ["./file"]
-    expect(await shouldOpenInExistingInstance(args)).toStrictEqual(undefined)
+    expect(await shouldOpenInExistingInstance(args, sessionSocket)).toStrictEqual(undefined)
 
-    const client = new EditorSessionManagerClient(DEFAULT_SOCKET_PATH)
+    const client = new EditorSessionManagerClient(sessionSocket)
     const socketPath = path.join(tmpDirPath, "socket")
     await client.addSession({
       entry: {
@@ -609,18 +615,19 @@ describe("cli", () => {
     })
     const vscodeSockets = listenOn(socketPath)
 
-    expect(await shouldOpenInExistingInstance(args)).toStrictEqual(socketPath)
+    expect(await shouldOpenInExistingInstance(args, sessionSocket)).toStrictEqual(socketPath)
 
     args.port = 8081
-    expect(await shouldOpenInExistingInstance(args)).toStrictEqual(undefined)
+    expect(await shouldOpenInExistingInstance(args, sessionSocket)).toStrictEqual(undefined)
 
     server.close()
     vscodeSockets.close()
   })
 
   it("should prefer matching sessions for only the first path", async () => {
-    const server = await makeEditorSessionManagerServer(DEFAULT_SOCKET_PATH, new EditorSessionManager())
-    const client = new EditorSessionManagerClient(DEFAULT_SOCKET_PATH)
+    const sessionSocket = path.join(tmpDirPath, "session-socket")
+    const server = await makeEditorSessionManagerServer(sessionSocket, new EditorSessionManager())
+    const client = new EditorSessionManagerClient(sessionSocket)
     await client.addSession({
       entry: {
         workspace: {
@@ -655,7 +662,7 @@ describe("cli", () => {
 
     const args: UserProvidedArgs = {}
     args._ = ["/aaa/file", "/bbb/file"]
-    expect(await shouldOpenInExistingInstance(args)).toStrictEqual(`${tmpDirPath}/vscode-ipc-aaa.sock`)
+    expect(await shouldOpenInExistingInstance(args, sessionSocket)).toStrictEqual(`${tmpDirPath}/vscode-ipc-aaa.sock`)
 
     server.close()
   })

--- a/test/unit/node/plugin.test.ts
+++ b/test/unit/node/plugin.test.ts
@@ -43,6 +43,7 @@ describe("plugin", () => {
         usingEnvHashedPassword: false,
         "extensions-dir": "",
         "user-data-dir": "",
+        "session-socket": "",
       }
       next()
     }

--- a/test/unit/node/vscodeSocket.test.ts
+++ b/test/unit/node/vscodeSocket.test.ts
@@ -1,18 +1,7 @@
 import { logger } from "@coder/logger"
 import * as app from "../../../src/node/app"
-import { paths } from "../../../src/node/util"
-import {
-  DEFAULT_SOCKET_PATH,
-  EditorSessionManager,
-  makeEditorSessionManagerServer,
-} from "../../../src/node/vscodeSocket"
+import { EditorSessionManager, makeEditorSessionManagerServer } from "../../../src/node/vscodeSocket"
 import { clean, tmpdir, listenOn, mockLogger } from "../../utils/helpers"
-
-describe("DEFAULT_SOCKET_PATH", () => {
-  it("should be a unique path per user", () => {
-    expect(DEFAULT_SOCKET_PATH.startsWith(paths.data)).toBe(true)
-  })
-})
 
 describe("makeEditorSessionManagerServer", () => {
   let tmpDirPath: string


### PR DESCRIPTION
While I was at it I added a CLI flag to override the default.  I also swapped the default to --user-data-dir.

The value is set on an environment variable so it can be used by the extension host similar to VSCODE_IPC_HOOK_CLI.

Continuation of a fix for https://github.com/coder/code-server/issues/6275.
