### PR TITLE
feat(helm): Don't create Secret if existingSecret is provided

### DIFF
--- a/ci/helm-chart/templates/secrets.yaml
+++ b/ci/helm-chart/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,8 +12,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
-  {{ if .Values.password }}
+  {{- if .Values.password }}
   password: "{{ .Values.password | b64enc }}"
-  {{ else }}
+  {{- else }}
   password: "{{ randAlphaNum 24 | b64enc }}"
-  {{ end }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
When I set `existingSecret` in values.yaml, a secret is still created even if it's not used. This PR removes it.

# Tests

```yaml
# secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: my-secret
type: Opaque
stringData:
  password: MySuperSecretPassword
```

```yaml
# values.yaml
existingSecret: my-secret
```

## Before

```yaml
# helm template ./ci/helm-chart -s templates/secrets.yaml
---
# Source: code-server/templates/secrets.yaml
apiVersion: v1
kind: Secret
metadata:
  name: release-name-code-server
  annotations:
    "helm.sh/hook": "pre-install"
  labels:
    app.kubernetes.io/name: code-server
    helm.sh/chart: code-server-3.12.1
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
type: Opaque
data:
# Here was a blank line I also removed in my PR
  password: "THh6aGdDYWZrUjMzNXlwdmxlbk95Z0g0"
```

## After

```
Error: could not find template templates/secrets.yaml in chart
```
