### PR TITLE
Modify manifest for window control overlay support

### DIFF
--- a/src/node/routes/vscode.ts
+++ b/src/node/routes/vscode.ts
@@ -55,6 +55,7 @@ export class CodeServerRouteWrapper {
             short_name: appName,
             start_url: ".",
             display: "fullscreen",
+            display_override: ["window-controls-overlay"],
             description: "Run Code on a remote server.",
             icons: [192, 512].map((size) => ({
               src: `{{BASE}}/_static/src/browser/media/pwa-icon-${size}.png`,


### PR DESCRIPTION
Since the release of code-server v4.17.0 (Code 1.82), "Command Center" has become a default option. However, the current code-server PWA app lacks support for the Windows control overlay, resulting in an untidy appearance of the title bar. This commit introduces modifications to the manifest file to enable support for the window control overlay.

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes #3884

[Prior to patch]
![image](https://github.com/coder/code-server/assets/16421480/9b59b3f1-5a37-4461-b401-5d64e2774c50)

[After the patch]
![image](https://github.com/coder/code-server/assets/16421480/42c08faa-cf65-4c5b-ad04-c3c1a986c217)

