### PR TITLE
Update default nginx config in guide.md

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -191,7 +191,7 @@ At this point, you should be able to access code-server via
 
        location / {
          proxy_pass http://localhost:8080/;
-         proxy_set_header Host $host;
+         proxy_set_header Host $http_host;
          proxy_set_header Upgrade $http_upgrade;
          proxy_set_header Connection upgrade;
          proxy_set_header Accept-Encoding gzip;


### PR DESCRIPTION
update nginx config to avoid wss error when expose code-server using a custom domain and a custom port via nginx.

see also: 
* [issue of code-server](https://github.com/coder/code-server/issues/4443) 
* [different between `$host` and `$http_host`](https://stackoverflow.com/a/76875724)

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes # https://github.com/coder/code-server/issues/4443
