### PR TITLE
Helm boolean fix

### DIFF
--- a/ci/helm-chart/values.yaml
+++ b/ci/helm-chart/values.yaml
@@ -71,7 +71,7 @@ extraArgs: []
 # Optional additional environment variables
 extraVars: []
 #  - name: DISABLE_TELEMETRY
-#    value: true
+#    value: "true"
 #  - name: DOCKER_HOST
 #    value: "tcp://localhost:2375"
 


### PR DESCRIPTION
<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Helm error:
* `cannot unmarshal bool into Go struct field EnvVar.spec.template.spec.containers.env.value of type string`

Must wrap any `true` or `false` into quotes when passing values to `env` object.



