### PR TITLE
⬆ Update and organize `apt` packages

### DIFF
--- a/ci/release-image/Dockerfile
+++ b/ci/release-image/Dockerfile
@@ -10,18 +10,18 @@ RUN apt-get update \
   && apt-get install -y \
     curl \
     dumb-init \
-    zsh \
-    htop \
-    locales \
-    man \
-    nano \
     git \
     git-lfs \
-    procps \
-    openssh-client \
-    sudo \
-    vim.tiny \
+    htop \
+    locales \
     lsb-release \
+    man-db \
+    nano \
+    openssh-client \
+    procps \
+    sudo \
+    vim-tiny \
+    zsh \
   && git lfs install \
   && rm -rf /var/lib/apt/lists/*
 
@@ -34,7 +34,7 @@ RUN adduser --gecos '' --disabled-password coder \
   && echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
 
 RUN ARCH="$(dpkg --print-architecture)" \
-  && curl -fsSL "https://github.com/boxboat/fixuid/releases/download/v0.5/fixuid-0.5-linux-$ARCH.tar.gz" | tar -C /usr/local/bin -xzf - \
+  && curl -fsSL "https://github.com/boxboat/fixuid/releases/download/v0.6.0/fixuid-0.6.0-linux-$ARCH.tar.gz" | tar -C /usr/local/bin -xzf - \
   && chown root:root /usr/local/bin/fixuid \
   && chmod 4755 /usr/local/bin/fixuid \
   && mkdir -p /etc/fixuid \

--- a/ci/release-image/Dockerfile
+++ b/ci/release-image/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
     procps \
     sudo \
     vim-tiny \
+    wget \
     zsh \
   && git lfs install \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
#### Description

- Use `man-db` instead of `man` *(as proposed by `apt`)*
- Use `vim-tiny` instead of `vim.tiny` *(as proposed by `apt`)*
- Sort requirements alphabetically
- Update `fixuid` version
- Add `wget` to the base package list as it is widely used and available by default on many Linux distros.

--- 

Regarding the suggestion to use `--no-install-recommends` from #6574, the difference between the two installs is minor:

```diff
- 1 upgraded, 74 newly installed, 0 to remove and 5 not upgraded.
+ 1 upgraded, 53 newly installed, 0 to remove and 5 not upgraded.
- After this operation, 200 MB of additional disk space will be used.
+ After this operation, 190 MB of additional disk space will be used.
```

As a conclusion, it is not worth the `~10MB` to possibly cause regressions.
