### PR TITLE
⚙ Add Debian bookworm config to bakefile

### DIFF
--- a/ci/release-image/docker-bake.hcl
+++ b/ci/release-image/docker-bake.hcl
@@ -16,7 +16,7 @@ variable "GITHUB_REGISTRY" {
 
 group "default" {
     targets = [
-        "code-server-debian-11", 
+        "code-server-debian-12",
         "code-server-ubuntu-focal",
     ]
 }
@@ -45,12 +45,12 @@ function "gen_tags_for_docker_and_ghcr" {
     )
 }
 
-target "code-server-debian-11" {
+target "code-server-debian-12" {
     dockerfile = "ci/release-image/Dockerfile"
     tags = concat(
         gen_tags_for_docker_and_ghcr(""),
         gen_tags_for_docker_and_ghcr("debian"),
-        gen_tags_for_docker_and_ghcr("bullseye"),
+        gen_tags_for_docker_and_ghcr("bookwork"),
     )
     platforms = ["linux/amd64", "linux/arm64"]
 }

--- a/ci/release-image/docker-bake.hcl
+++ b/ci/release-image/docker-bake.hcl
@@ -50,7 +50,7 @@ target "code-server-debian-12" {
     tags = concat(
         gen_tags_for_docker_and_ghcr(""),
         gen_tags_for_docker_and_ghcr("debian"),
-        gen_tags_for_docker_and_ghcr("bookwork"),
+        gen_tags_for_docker_and_ghcr("bookworm"),
     )
     platforms = ["linux/amd64", "linux/arm64"]
 }


### PR DESCRIPTION
The `docker-bake.hcl` was not updated with references to Debian 12 *(Bookwork)*.

Related #6574
