### PR TITLE
chore: add Dockerfile for VS Code Server and Caddy configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# Use a base image of Ubuntu
+FROM ubuntu:latest
+
+# Update the system and install curl
+RUN apt-get update && apt-get install -y curl
+
+# Create a non-root user and a directory for VS Code Server
+RUN useradd -m vscode
+RUN mkdir /home/vscode/workplace
+RUN chown -R vscode:vscode /home/vscode/workplace
+
+# Download and install VS Code Server
+RUN curl -fsSL https://code-server.dev/install.sh | sh
+
+# Install NVM
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+
+# Install Caddy
+RUN apt-get install -y debian-keyring debian-archive-keyring apt-transport-https
+RUN curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main" | tee /etc/apt/sources.list.d/caddy-stable.list
+RUN apt-get update
+RUN apt-get install caddy
+
+# Add Caddy configuration file
+RUN echo "example.com {\n  reverse_proxy 127.0.0.1:8080\n}" > /etc/caddy/Caddyfile
+
+# Switch to non-root user
+USER vscode
+
+# Set CODE_SERVER_USER_DATA_DIR environment variable
+ENV CODE_SERVER_USER_DATA_DIR=/home/vscode/workplace
+
+# Expose port 8080
+EXPOSE 8080
+
+# Start VS Code Server and Caddy when the container is started
+CMD /bin/bash -c "code-server --bind-addr 0.0.0.0:8080 & caddy run"


### PR DESCRIPTION
## Description
This PR introduces a Dockerfile that sets up a VS Code Server environment. The Dockerfile is based on Ubuntu and includes installations of curl, NVM, Caddy, and VS Code Server. It also sets up a non-root user and a workplace directory for the VS Code Server.

## Usage
To use this Dockerfile, please replace example.com in the Caddy configuration file with your own domain. (line 26 of Dockerfile)

### Build the Docker image
```
docker build -t vscode-server .
```
### Run the Docker container
```
docker run -p 8080:8080 vscode-server
```
## Motivation
I created this PR because I’ve been working with a client who requires me to access their virtual machine for development. However, their environment is quite limited, and I don’t have admin access, which restricts what I can do. Hosting the VS Code Server on my server solved all my problems, so I decided to share my Dockerfile to help others who might be in a similar situation.