### PR TITLE
Fix segfault in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -206,6 +206,7 @@ jobs:
     timeout-minutes: 60
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      DISABLE_V8_COMPILE_CACHE: 1
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Experimenting with fixing the segfault happening when building VS Code in CI.

- [x] Use Node 20.12.1 <- did not work, still segfaulting
- [x] Set DISABLE_V8_COMPILE_CACHE=1 (seems related to pnpm, so probably will not help) <- actually worked
- [x] Clear Node module cache maybe? <- no change