### PR TITLE
feat: introduce --abs-proxy-base-path that allows app proxying while code-server is not server at the root

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -432,3 +432,12 @@ const config = {
 3. Access app at `<code-server-root>/absproxy/5173/` e.g. `http://localhost:8080/absproxy/5173/
 
 For additional context, see [this Github Issue](https://github.com/sveltejs/kit/issues/2958)
+
+### Prefixing `/absproxy/<port>` with a path
+
+This is a case where you need to serve an application via `absproxy` as explained above while serving `codeserver` itself from a path other than the root in your domain.
+
+For example: `http://my-code-server.com/user/123/workspace/my-app`. To achieve this result:
+
+1. start code server with the switch `--abs-proxy-base-path=/user/123/workspace`
+2. Follow one of the instructions above for your framework.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -20,6 +20,7 @@
   - [Proxying to a Vue app](#proxying-to-a-vue-app)
   - [Proxying to an Angular app](#proxying-to-an-angular-app)
   - [Proxying to a Svelte app](#proxying-to-a-svelte-app)
+  - [Prefixing `/absproxy/<port>` with a path](#prefixing-absproxyport-with-a-path)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- prettier-ignore-end -->

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -440,5 +440,5 @@ This is a case where you need to serve an application via `absproxy` as explaine
 
 For example: `http://my-code-server.com/user/123/workspace/my-app`. To achieve this result:
 
-1. start code server with the switch `--abs-proxy-base-path=/user/123/workspace`
+1. Start code server with the switch `--abs-proxy-base-path=/user/123/workspace`
 2. Follow one of the instructions above for your framework.

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -53,6 +53,7 @@ export interface UserProvidedCodeArgs {
   "disable-getting-started-override"?: boolean
   "disable-proxy"?: boolean
   "session-socket"?: string
+  "abs-proxy-base-path"?: string
 }
 
 /**
@@ -117,18 +118,18 @@ interface Option<T> {
 type OptionType<T> = T extends boolean
   ? "boolean"
   : T extends OptionalString
-  ? typeof OptionalString
-  : T extends LogLevel
-  ? typeof LogLevel
-  : T extends AuthType
-  ? typeof AuthType
-  : T extends number
-  ? "number"
-  : T extends string
-  ? "string"
-  : T extends string[]
-  ? "string[]"
-  : "unknown"
+    ? typeof OptionalString
+    : T extends LogLevel
+      ? typeof LogLevel
+      : T extends AuthType
+        ? typeof AuthType
+        : T extends number
+          ? "number"
+          : T extends string
+            ? "string"
+            : T extends string[]
+              ? "string[]"
+              : "unknown"
 
 export type Options<T> = {
   [P in keyof T]: Option<OptionType<T[P]>>
@@ -278,6 +279,10 @@ export const options: Options<Required<UserProvidedArgs>> = {
     type: "string",
     short: "w",
     description: "Text to show on login page",
+  },
+  "abs-proxy-base-path": {
+    type: "string",
+    description: "The base path to prefix all absproxy requests",
   },
 }
 

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -118,18 +118,18 @@ interface Option<T> {
 type OptionType<T> = T extends boolean
   ? "boolean"
   : T extends OptionalString
-    ? typeof OptionalString
-    : T extends LogLevel
-      ? typeof LogLevel
-      : T extends AuthType
-        ? typeof AuthType
-        : T extends number
-          ? "number"
-          : T extends string
-            ? "string"
-            : T extends string[]
-              ? "string[]"
-              : "unknown"
+  ? typeof OptionalString
+  : T extends LogLevel
+  ? typeof LogLevel
+  : T extends AuthType
+  ? typeof AuthType
+  : T extends number
+  ? "number"
+  : T extends string
+  ? "string"
+  : T extends string[]
+  ? "string[]"
+  : "unknown"
 
 export type Options<T> = {
   [P in keyof T]: Option<OptionType<T[P]>>
@@ -282,7 +282,7 @@ export const options: Options<Required<UserProvidedArgs>> = {
   },
   "abs-proxy-base-path": {
     type: "string",
-    description: "The base path to prefix all absproxy requests",
+    description: "The base path to prefix to all absproxy requests",
   },
 }
 

--- a/src/node/routes/index.ts
+++ b/src/node/routes/index.ts
@@ -121,11 +121,13 @@ export const register = async (app: App, args: DefaultedArgs): Promise<Disposabl
   app.router.all("/absproxy/:port/:path(.*)?", async (req, res) => {
     await pathProxy.proxy(req, res, {
       passthroughPath: true,
+      proxyBasePath: args["abs-proxy-base-path"],
     })
   })
   app.wsRouter.get("/absproxy/:port/:path(.*)?", async (req) => {
     await pathProxy.wsProxy(req as pluginapi.WebsocketRequest, {
       passthroughPath: true,
+      proxyBasePath: args["abs-proxy-base-path"],
     })
   })
 

--- a/src/node/routes/pathProxy.ts
+++ b/src/node/routes/pathProxy.ts
@@ -5,10 +5,15 @@ import { HttpCode, HttpError } from "../../common/http"
 import { ensureProxyEnabled, authenticated, ensureAuthenticated, ensureOrigin, redirect, self } from "../http"
 import { proxy as _proxy } from "../proxy"
 
-const getProxyTarget = (req: Request): string => {
+const getProxyTarget = (
+  req: Request,
+  opts?: {
+    proxyBasePath?: string
+  },
+): string => {
   // If there is a base path, strip it out.
   const base = (req as any).base || ""
-  return `http://0.0.0.0:${req.params.port}/${req.originalUrl.slice(base.length)}`
+  return `http://0.0.0.0:${req.params.port}${opts?.proxyBasePath || ""}/${req.originalUrl.slice(base.length)}`
 }
 
 export async function proxy(
@@ -16,6 +21,7 @@ export async function proxy(
   res: Response,
   opts?: {
     passthroughPath?: boolean
+    proxyBasePath?: string
   },
 ): Promise<void> {
   ensureProxyEnabled(req)
@@ -38,7 +44,7 @@ export async function proxy(
 
   _proxy.web(req, res, {
     ignorePath: true,
-    target: getProxyTarget(req),
+    target: getProxyTarget(req, opts),
   })
 }
 
@@ -46,6 +52,7 @@ export async function wsProxy(
   req: pluginapi.WebsocketRequest,
   opts?: {
     passthroughPath?: boolean
+    proxyBasePath?: string
   },
 ): Promise<void> {
   ensureProxyEnabled(req)
@@ -59,6 +66,6 @@ export async function wsProxy(
 
   _proxy.ws(req, req.ws, req.head, {
     ignorePath: true,
-    target: getProxyTarget(req),
+    target: getProxyTarget(req, opts),
   })
 }

--- a/test/unit/node/cli.test.ts
+++ b/test/unit/node/cli.test.ts
@@ -106,6 +106,8 @@ describe("parser", () => {
 
           "--disable-proxy",
 
+          ["--abs-proxy-base-path", "/codeserver/app1"],
+
           ["--session-socket", "/tmp/override-code-server-ipc-socket"],
 
           ["--host", "0.0.0.0"],
@@ -143,6 +145,7 @@ describe("parser", () => {
       version: true,
       "bind-addr": "192.169.0.1:8080",
       "session-socket": "/tmp/override-code-server-ipc-socket",
+      "abs-proxy-base-path": "/codeserver/app1",
     })
   })
 

--- a/test/unit/node/proxy.test.ts
+++ b/test/unit/node/proxy.test.ts
@@ -256,6 +256,18 @@ describe("proxy", () => {
       expect(spy).toHaveBeenCalledWith([test.expected, test.query])
     }
   })
+
+  it("should allow specifying an absproxy path", async () => {
+    const prefixedPath = `/codeserver/app1${absProxyPath}`
+    e.get(prefixedPath, (req, res) => {
+      res.send("app being served behind a prefixed path")
+    })
+    codeServer = await integration.setup(["--auth=none", "--abs-proxy-base-path=/codeserver/app1"], "")
+    const resp = await codeServer.fetch(absProxyPath)
+    expect(resp.status).toBe(200)
+    const text = await resp.text()
+    expect(text).toBe("app being served behind a prefixed path")
+  })
 })
 
 // NOTE@jsjoeio


### PR DESCRIPTION
## What it is
- Allows proxy traffic to be properly routed when `code-server` is served under a path.

## How
- Introduces a new switch `abs-proxy-base-path`.
- When specified, `absproxy` requests will be forwarded using the value as prefix

## Example
- Code server is hosted at: `my-codeserver.com/user/123`
- React App is started at port 8080 under `PUBLIC_PATH` `/user/123`
- `abs-proxy-base-path` set to `/user/123`
- A `GET` request to `my-codeserver.com/user/123/absproxy/8080/app` will properly reach the app.

Fixes #6770
