### PR TITLE
Fix install.sh refusing to download macos-arm64 standalone.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -461,9 +461,9 @@ npm_fallback() {
 # Determine if we have standalone releases on GitHub for the system's arch.
 has_standalone() {
   case $ARCH in
-    amd64) return 0 ;;
-    # We only have amd64 for macOS.
-    arm64)
+    arm64) return 0 ;;
+    # We only have arm64 for macOS.
+    amd64)
       [ "$(distro)" != macos ]
       return
       ;;

--- a/test/scripts/install.bats
+++ b/test/scripts/install.bats
@@ -132,15 +132,15 @@ function should-use-standalone() {
 
 # macOS use homebrew but falls back to standalone when brew is unavailable then
 # to npm for unsupported architectures.
-@test "$SCRIPT_NAME: macos arm64 (no brew)" {
-  should-fallback-npm-brew "arm64"
-}
 @test "$SCRIPT_NAME: macos amd64 (no brew)" {
-  BREW_PATH= OS=macos ARCH=amd64 run "$SCRIPT" --dry-run
+  should-fallback-npm-brew "amd64"
+}
+@test "$SCRIPT_NAME: macos arm64 (no brew)" {
+  BREW_PATH= OS=macos ARCH=arm64 run "$SCRIPT" --dry-run
   [ "$status" -eq 0 ]
   [ "${lines[1]}" = "Homebrew not installed." ]
   [ "${lines[2]}" = "Falling back to standalone installation." ]
-  [ "${lines[3]}" = "Installing v$VERSION of the amd64 release from GitHub." ]
+  [ "${lines[3]}" = "Installing v$VERSION of the arm64 release from GitHub." ]
   [[ "${lines[-6]}" = "Standalone release has been installed"* ]]
 }
 @test "$SCRIPT_NAME: macos i386 (no brew)" {


### PR DESCRIPTION
<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes part of https://github.com/coder/code-server/issues/6659#issuecomment-2318943559

Ever since [v4.89.0-rc.1](https://github.com/coder/code-server/releases/tag/v4.89.0-rc.1), there's only macos-arm64 but no more amd64. This fixes the script to align with the actual release artifacts.

In the long run, if we ever add back macos-amd64, the check can be removed entirely. 