### PR TITLE
chore: update and pinned prettier to version 3.4.2 and fix ci

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Prettier 3.4.2
+9b0340a09276f93c054d705d1b9a5f24cc5dbc97

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,17 +23,25 @@ concurrency:
 
 jobs:
   prettier:
-    name: Format with Prettier
+    name: Run prettier check
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Run prettier with actionsx/prettier
-        uses: actionsx/prettier@v3
+      - name: Install Node.js
+        uses: actions/setup-node@v4
         with:
-          args: --check --log-level=warn .
+          node-version-file: .node-version
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            test/package-lock.json
+
+      - run: SKIP_SUBMODULE_DEPS=1 npm ci
+
+      - run: npx prettier --check .
 
   doctoc:
     name: Doctoc markdown files

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "eslint-plugin-import": "^2.28.1",
         "eslint-plugin-prettier": "^5.0.0",
         "globals": "^15.10.0",
-        "prettier": "^3.0.3",
+        "prettier": "3.4.2",
         "prettier-plugin-sh": "^0.14.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.6.2",
@@ -4643,10 +4643,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.0",
     "globals": "^15.10.0",
-    "prettier": "^3.0.3",
+    "prettier": "3.4.2",
     "prettier-plugin-sh": "^0.14.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.6.2",

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -118,18 +118,18 @@ interface Option<T> {
 type OptionType<T> = T extends boolean
   ? "boolean"
   : T extends OptionalString
-  ? typeof OptionalString
-  : T extends LogLevel
-  ? typeof LogLevel
-  : T extends AuthType
-  ? typeof AuthType
-  : T extends number
-  ? "number"
-  : T extends string
-  ? "string"
-  : T extends string[]
-  ? "string[]"
-  : "unknown"
+    ? typeof OptionalString
+    : T extends LogLevel
+      ? typeof LogLevel
+      : T extends AuthType
+        ? typeof AuthType
+        : T extends number
+          ? "number"
+          : T extends string
+            ? "string"
+            : T extends string[]
+              ? "string[]"
+              : "unknown"
 
 export type Options<T> = {
   [P in keyof T]: Option<OptionType<T[P]>>


### PR DESCRIPTION
According to the `Prettier` [documentation](https://prettier.io/docs/en/install#summary), we should always install an **exact version**:

> Install an **exact version** of Prettier locally in your project. This makes sure that everyone in the project gets the exact same version of Prettier. Even a patch release of Prettier can result in slightly different formatting, so you wouldn’t want different team members using different versions and formatting each other’s changes back and forth.

That is, in `package.json` it should look like `"prettier": "3.0.3"` instead of `"prettier": "^3.0.3"`.

Don’t forget the `--save-exact` parameter when installing or updating the `prettier`:

```sh
npm install --save-dev --save-exact prettier@3.4.2
```

Otherwise, following the [Development workflow](https://github.com/coder/code-server/blob/main/docs/CONTRIBUTING.md#development-workflow), one can easily get different `prettier` versions and end up with `CI` failing, and this is often a source of confusion.

Therefore, this PR mainly **pinned** the version of `prettier` and updates it to the latest version v3.4.2 by the way.

It's worth noting that I added the `commit` hash of the actual formatted code in `.git-blame-ignore-revs` to ignore non-actual code changes for git blame.
- It is recommended that future `prettier` version updates take the same action
- So note that this PR should NOT be squash/rebase merge, otherwise the commit hash ​​will not match
  - Or you could revise the commit hash in `.git-blame-ignore-revs` after merging

---

The original CI process uses the third-party workflow `actionsx/prettier@v3` with a fixed version of `prettier` (currently seems to be 3.0), which is another cause of confusion.

We should always use the version specified in `package.json`, and always maintain version numbers in one place.

The speed difference is insignificant here, and it's not a shortcoming in the overall CI process.