### PR TITLE
Add optional idle timeout shutdown 

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -83,6 +83,7 @@ export interface UserProvidedArgs extends UserProvidedCodeArgs {
   "socket-mode"?: string
   "trusted-origins"?: string[]
   version?: boolean
+  "idle-timeout"?: number
   "proxy-domain"?: string[]
   "reuse-window"?: boolean
   "new-window"?: boolean
@@ -137,6 +138,13 @@ export type Options<T> = {
 
 export const options: Options<Required<UserProvidedArgs>> = {
   auth: { type: AuthType, description: "The type of authentication to use." },
+<<<<<<< HEAD
+=======
+  "auth-user": {
+     type: "string",
+     description: "The username for http-basic authentication."
+  },
+>>>>>>> c6a85663 (Add idle-timeout: Timeout in minutes to wait before shutting down when idle)
   password: {
     type: "string",
     description: "The password for password authentication (can only be passed in via $PASSWORD or the config file).",
@@ -251,6 +259,7 @@ export const options: Options<Required<UserProvidedArgs>> = {
     type: "string",
     description: "GitHub authentication token (can only be passed in via $GITHUB_TOKEN or the config file).",
   },
+  "idle-timeout": { type: "number", description: "Timeout in minutes to wait before shutting down when idle." },
   "proxy-domain": { type: "string[]", description: "Domain used for proxying ports." },
   "ignore-last-opened": {
     type: "boolean",
@@ -477,6 +486,7 @@ export interface DefaultedArgs extends ConfigArgs {
   }
   host: string
   port: number
+  "idle-timeout": number
   "proxy-domain": string[]
   verbose: boolean
   usingEnvPassword: boolean
@@ -568,6 +578,10 @@ export async function setDefaults(cliArgs: UserProvidedArgs, configArgs?: Config
   let usingEnvPassword = !!process.env.PASSWORD
   if (process.env.PASSWORD) {
     args.password = process.env.PASSWORD
+  }
+
+  if (process.env.IDLE_TIMEOUT) {
+    args["idle-timeout"] = parseInt(process.env.IDLE_TIMEOUT, 10)
   }
 
   if (process.env.CS_DISABLE_FILE_DOWNLOADS?.match(/^(1|true)$/)) {

--- a/src/node/heart.ts
+++ b/src/node/heart.ts
@@ -1,5 +1,6 @@
 import { logger } from "@coder/logger"
 import { promises as fs } from "fs"
+import { wrapper } from "./wrapper"
 
 /**
  * Provides a heartbeat using a local file to indicate activity.
@@ -56,7 +57,7 @@ export class Heart {
       const timeSinceLastBeat = Date.now() - this.lastHeartbeat
       if (timeSinceLastBeat > this.idleTimeout! * 60 * 1000) {
         logger.warn(`Idle timeout of ${this.idleTimeout} minutes exceeded`)
-        process.kill(process.pid, "SIGTERM")
+        wrapper.exit(5)
       }
     }, 60000)
   }

--- a/src/node/main.ts
+++ b/src/node/main.ts
@@ -152,6 +152,10 @@ export const runCodeServer = async (
     logger.info("  - Not serving HTTPS")
   }
 
+  if (args["idle-timeout"]) {
+    logger.info(`  - Idle timeout set to ${args["idle-timeout"]} minutes`)
+  }
+
   if (args["disable-proxy"]) {
     logger.info("  - Proxy disabled")
   } else if (args["proxy-domain"].length > 0) {

--- a/src/node/routes/index.ts
+++ b/src/node/routes/index.ts
@@ -31,7 +31,7 @@ import * as vscode from "./vscode"
  * Register all routes and middleware.
  */
 export const register = async (app: App, args: DefaultedArgs): Promise<Disposable["dispose"]> => {
-  const heart = new Heart(path.join(paths.data, "heartbeat"), async () => {
+  const heart = new Heart(path.join(paths.data, "heartbeat"), args["idle-timeout"], async () => {
     return new Promise((resolve, reject) => {
       // getConnections appears to not call the callback when there are no more
       // connections.  Feels like it must be a bug?  For now add a timer to make

--- a/test/unit/node/heart.test.ts
+++ b/test/unit/node/heart.test.ts
@@ -95,7 +95,7 @@ describe("heartbeatTimer", () => {
     const isActive = true
     const mockIsActive = jest.fn().mockResolvedValue(isActive)
     const mockBeatFn = jest.fn()
-    await heartbeatTimer(mockIsActive, mockBeatFn, 0)
+    await heartbeatTimer(mockIsActive, mockBeatFn)
     expect(mockIsActive).toHaveBeenCalled()
     expect(mockBeatFn).toHaveBeenCalled()
   })
@@ -104,7 +104,7 @@ describe("heartbeatTimer", () => {
     const error = new Error(errorMsg)
     const mockIsActive = jest.fn().mockRejectedValue(error)
     const mockBeatFn = jest.fn()
-    await heartbeatTimer(mockIsActive, mockBeatFn, 0)
+    await heartbeatTimer(mockIsActive, mockBeatFn)
     expect(mockIsActive).toHaveBeenCalled()
     expect(mockBeatFn).not.toHaveBeenCalled()
     expect(logger.warn).toHaveBeenCalledWith(errorMsg)

--- a/test/unit/node/heart.test.ts
+++ b/test/unit/node/heart.test.ts
@@ -95,7 +95,7 @@ describe("heartbeatTimer", () => {
     const isActive = true
     const mockIsActive = jest.fn().mockResolvedValue(isActive)
     const mockBeatFn = jest.fn()
-    await heartbeatTimer(mockIsActive, mockBeatFn)
+    await heartbeatTimer(mockIsActive, mockBeatFn, 0)
     expect(mockIsActive).toHaveBeenCalled()
     expect(mockBeatFn).toHaveBeenCalled()
   })
@@ -104,7 +104,7 @@ describe("heartbeatTimer", () => {
     const error = new Error(errorMsg)
     const mockIsActive = jest.fn().mockRejectedValue(error)
     const mockBeatFn = jest.fn()
-    await heartbeatTimer(mockIsActive, mockBeatFn)
+    await heartbeatTimer(mockIsActive, mockBeatFn, 0)
     expect(mockIsActive).toHaveBeenCalled()
     expect(mockBeatFn).not.toHaveBeenCalled()
     expect(logger.warn).toHaveBeenCalledWith(errorMsg)


### PR DESCRIPTION
I did this for my needs but realized there is a closed issue (not implemented) that is requesting the same thing.

Through the idle-timeout arg or IDLE_TIMEOUT environment variable, after the specified number of minutes since the heartbeat was last refreshed is detected, the code-server process shuts down. When run as the single process of a docker container, this just stops the container.

Fixes #1636
