### PR TITLE
Update guide.md: Reverse Proxying Server-Side Requests

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -343,6 +343,18 @@ built-in subpath-based proxy.
 Note: relative paths are also supported i.e.
 `VSCODE_PROXY_URI=./proxy/{{port}}`
 
+It may also be neccesary to reroute server side requests through your
+reverse proxy as well. This is the preferred method described [here](https://coder.com/docs/code-server/FAQ#how-do-i-direct-server-side-requests-through-a-proxy)
+as it will preserve the functionality desrcibed above. This can be  done by
+configuring the enviornment variable(s) `HTTP_PROXY` and/or `HTTPS_PROXY` to
+the address or hostname of your reverse proxy.
+
+This will also resolve hostnames, including within docker networks. For
+example, if your reverse proxy is a Caddy container named `caddy`, on the
+same docker network as `code-server`, you could set
+`HTTPS_PROXY=https://caddy/` in the `enviornment:` block of the
+`compose.yml`. 
+
 ### Stripping `/proxy/<port>` from the request path
 
 You may notice that the code-server proxy strips `/proxy/<port>` from the


### PR DESCRIPTION
## Description
Minor `guide.md` Addition: Added necessary documentation to redirect server-side requests to an external proxy by setting the environment variable(s) `HTTPS_PROXY` and/or `HTTP_PROXY`. Included a link to [official Coder documentation](https://coder.com/docs/code-server/FAQ#how-do-i-direct-server-side-requests-through-a-proxy).

## Issue Link
As this is a very minor fix, I did not create an issue.

## Fixes
In the `using your own proxy` section of [guide.md](), there is no current documentation about forwarding server-side requests to a reverse proxy, which is often required to make the webapp functional behind your own reverse proxy. This is was my first time reverse proxying a web app, and had trouble finding this documentation until I found it in the [FAQ Section of the Coder Docs](https://coder.com/docs/code-server/FAQ#how-do-i-direct-server-side-requests-through-a-proxy), which I link to in the documentation for further reading.

This is my first PR, apologies for any mistakes! 
