### PR TITLE
Allow OPTIONS requests through domain proxy

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -84,6 +84,7 @@ export interface UserProvidedArgs extends UserProvidedCodeArgs {
   "trusted-origins"?: string[]
   version?: boolean
   "proxy-domain"?: string[]
+  "skip-auth-preflight"?: boolean
   "reuse-window"?: boolean
   "new-window"?: boolean
   "ignore-last-opened"?: boolean
@@ -252,6 +253,7 @@ export const options: Options<Required<UserProvidedArgs>> = {
     description: "GitHub authentication token (can only be passed in via $GITHUB_TOKEN or the config file).",
   },
   "proxy-domain": { type: "string[]", description: "Domain used for proxying ports." },
+  "skip-auth-preflight": { type: 'boolean', description: "Allows preflight requests through proxy without authentication." },
   "ignore-last-opened": {
     type: "boolean",
     short: "e",

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -253,7 +253,10 @@ export const options: Options<Required<UserProvidedArgs>> = {
     description: "GitHub authentication token (can only be passed in via $GITHUB_TOKEN or the config file).",
   },
   "proxy-domain": { type: "string[]", description: "Domain used for proxying ports." },
-  "skip-auth-preflight": { type: 'boolean', description: "Allows preflight requests through proxy without authentication." },
+  "skip-auth-preflight": {
+    type: "boolean",
+    description: "Allows preflight requests through proxy without authentication.",
+  },
   "ignore-last-opened": {
     type: "boolean",
     short: "e",

--- a/src/node/main.ts
+++ b/src/node/main.ts
@@ -163,6 +163,9 @@ export const runCodeServer = async (
     logger.info(`  - ${plural(args["proxy-domain"].length, "Proxying the following domain")}:`)
     args["proxy-domain"].forEach((domain) => logger.info(`    - ${domain}`))
   }
+  if (args["skip-auth-preflight"]) {
+    logger.info("  - Skipping authentication for preflight requests")
+  }
   if (process.env.VSCODE_PROXY_URI) {
     logger.info(`Using proxy URI in PORTS tab: ${process.env.VSCODE_PROXY_URI}`)
   }

--- a/src/node/routes/domainProxy.ts
+++ b/src/node/routes/domainProxy.ts
@@ -61,7 +61,7 @@ router.all(/.*/, async (req, res, next) => {
 
   ensureProxyEnabled(req)
 
-  if (req.method === "OPTIONS" && req.args['skip-auth-preflight']) {
+  if (req.method === "OPTIONS" && req.args["skip-auth-preflight"]) {
     // Allow preflight requests with `skip-auth-preflight` flag
     return next()
   }

--- a/src/node/routes/domainProxy.ts
+++ b/src/node/routes/domainProxy.ts
@@ -69,6 +69,11 @@ router.all(/.*/, async (req, res, next) => {
       return next()
     }
 
+    // OPTIONS requests should be allowed without credentials
+    if (req.method === "OPTIONS") {
+      return next()
+    }
+
     // Assume anything that explicitly accepts text/html is a user browsing a
     // page (as opposed to an xhr request). Don't use `req.accepts()` since
     // *every* request that I've seen (in Firefox and Chromium at least)

--- a/src/node/routes/domainProxy.ts
+++ b/src/node/routes/domainProxy.ts
@@ -61,16 +61,16 @@ router.all(/.*/, async (req, res, next) => {
 
   ensureProxyEnabled(req)
 
+  if (req.method === "OPTIONS" && req.args['skip-auth-preflight']) {
+    // Allow preflight requests with `skip-auth-preflight` flag
+    return next()
+  }
+
   // Must be authenticated to use the proxy.
   const isAuthenticated = await authenticated(req)
   if (!isAuthenticated) {
     // Let the assets through since they're used on the login page.
     if (req.path.startsWith("/_static/") && req.method === "GET") {
-      return next()
-    }
-
-    // OPTIONS requests should be allowed without credentials
-    if (req.method === "OPTIONS") {
       return next()
     }
 

--- a/src/node/routes/pathProxy.ts
+++ b/src/node/routes/pathProxy.ts
@@ -26,7 +26,7 @@ export async function proxy(
 ): Promise<void> {
   ensureProxyEnabled(req)
 
-  if (req.method === "OPTIONS" && req.args['skip-auth-preflight']) {
+  if (req.method === "OPTIONS" && req.args["skip-auth-preflight"]) {
     // Allow preflight requests with `skip-auth-preflight` flag
   } else if (!(await authenticated(req))) {
     // If visiting the root (/:port only) redirect to the login page.

--- a/src/node/routes/pathProxy.ts
+++ b/src/node/routes/pathProxy.ts
@@ -26,7 +26,9 @@ export async function proxy(
 ): Promise<void> {
   ensureProxyEnabled(req)
 
-  if (!(await authenticated(req))) {
+  if (req.method === "OPTIONS" && req.args['skip-auth-preflight']) {
+    // Allow preflight requests with `skip-auth-preflight` flag
+  } else if (!(await authenticated(req))) {
     // If visiting the root (/:port only) redirect to the login page.
     if (!req.params.path || req.params.path === "/") {
       const to = self(req)

--- a/test/unit/node/cli.test.ts
+++ b/test/unit/node/cli.test.ts
@@ -108,6 +108,8 @@ describe("parser", () => {
 
           ["--abs-proxy-base-path", "/codeserver/app1"],
 
+          "--skip-auth-preflight",
+
           ["--session-socket", "/tmp/override-code-server-ipc-socket"],
 
           ["--host", "0.0.0.0"],
@@ -146,6 +148,7 @@ describe("parser", () => {
       "bind-addr": "192.169.0.1:8080",
       "session-socket": "/tmp/override-code-server-ipc-socket",
       "abs-proxy-base-path": "/codeserver/app1",
+      "skip-auth-preflight": true,
     })
   })
 

--- a/test/unit/node/proxy.test.ts
+++ b/test/unit/node/proxy.test.ts
@@ -272,7 +272,7 @@ describe("proxy", () => {
   it("should not allow OPTIONS without authentication by default", async () => {
     process.env.PASSWORD = "test"
     codeServer = await integration.setup(["--auth=password"])
-    const resp = await codeServer.fetch(proxyPath, { method: "OPTIONS"})
+    const resp = await codeServer.fetch(proxyPath, { method: "OPTIONS" })
     expect(resp.status).toBe(401)
   })
 
@@ -280,7 +280,7 @@ describe("proxy", () => {
     process.env.PASSWORD = "test"
     codeServer = await integration.setup(["--auth=password", "--skip-auth-preflight"])
     e.post("/wsup", (req, res) => {})
-    const resp = await codeServer.fetch(proxyPath, { method: "OPTIONS"})
+    const resp = await codeServer.fetch(proxyPath, { method: "OPTIONS" })
     expect(resp.status).toBe(200)
   })
 })

--- a/test/unit/node/proxy.test.ts
+++ b/test/unit/node/proxy.test.ts
@@ -268,6 +268,21 @@ describe("proxy", () => {
     const text = await resp.text()
     expect(text).toBe("app being served behind a prefixed path")
   })
+
+  it("should not allow OPTIONS without authentication by default", async () => {
+    process.env.PASSWORD = "test"
+    codeServer = await integration.setup(["--auth=password"])
+    const resp = await codeServer.fetch(proxyPath, { method: "OPTIONS"})
+    expect(resp.status).toBe(401)
+  })
+
+  it("should allow OPTIONS with `skip-auth-preflight` flag", async () => {
+    process.env.PASSWORD = "test"
+    codeServer = await integration.setup(["--auth=password", "--skip-auth-preflight"])
+    e.post("/wsup", (req, res) => {})
+    const resp = await codeServer.fetch(proxyPath, { method: "OPTIONS"})
+    expect(resp.status).toBe(200)
+  })
 })
 
 // NOTE@jsjoeio


### PR DESCRIPTION
Fixes #7283

I believe the fix is as simple as allowing OPTIONS requests to pass through the proxy without authentication. Then the service behind the proxy should respond with 200 or 204.
