### PR TITLE
Adding a mention of code-server devcontainer feature

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ on how to set up a Google VM on which you can install code-server.
 
 ## Getting started
 
-There are four ways to get started:
+There are five ways to get started:
 
 1. Using the [install
    script](https://github.com/coder/code-server/blob/main/install.sh), which
@@ -35,6 +35,7 @@ There are four ways to get started:
 3. Deploy code-server to your team with [coder/coder](https://cdr.co/coder-github)
 4. Using our one-click buttons and guides to [deploy code-server to a cloud
    provider](https://github.com/coder/deploy-code-server) ⚡
+5. Using [code-server feature for devcontainers](https://github.com/coder/devcontainer-features?tab=readme-ov-file#code-server), in case you already use devcontainers in your project.
 
 If you use the install script, you can preview what occurs during the install
 process:

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ There are five ways to get started:
 3. Deploy code-server to your team with [coder/coder](https://cdr.co/coder-github)
 4. Using our one-click buttons and guides to [deploy code-server to a cloud
    provider](https://github.com/coder/deploy-code-server) ⚡
-5. Using [code-server feature for devcontainers](https://github.com/coder/devcontainer-features?tab=readme-ov-file#code-server), in case you already use devcontainers in your project.
+5. Using [code-server feature for devcontainers](https://github.com/coder/devcontainer-features/blob/main/README.md), in case you already use devcontainers in your project.
 
 If you use the install script, you can preview what occurs during the install
 process:


### PR DESCRIPTION
The change is in "getting started" section and lists using the devcontainer feature of code-server (a separate GH project) as a potential method of using code-server in one's projects.
