### PR TITLE
fix: update GitHub Actions Runner images

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -43,7 +43,7 @@ jobs:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/autobuild to send a status report
     name: Analyze with CodeQL
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/trivy-docker.yaml
+++ b/.github/workflows/trivy-docker.yaml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   trivy-scan-image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
GHA `ubuntu-20.04` image is fully deprecated:
https://github.com/actions/runner-images/issues/11101

Updating to `ubuntu-20.04` as per:
https://github.com/actions/runner-images?tab=readme-ov-file#available-images

Closes https://github.com/coder/security/issues/85
