### PR TITLE
[Helm Chart] Update values.yaml to better support docker

### DIFF
--- a/ci/helm-chart/values.yaml
+++ b/ci/helm-chart/values.yaml
@@ -75,8 +75,9 @@ extraArgs: []
 extraVars: []
 #  - name: DISABLE_TELEMETRY
 #    value: "true"
+# if dind is desired:
 #  - name: DOCKER_HOST
-#    value: "tcp://localhost:2375"
+#    value: "tcp://localhost:2376"
 
 ##
 ## Init containers parameters:
@@ -139,25 +140,39 @@ lifecycle:
   #      - -c
   #      - curl -s -L SOME_SCRIPT | bash
 
+  # for dind, the following may be helpful
+  # postStart:
+  #   exec:
+  #     command:
+  #       - /bin/sh
+  #       - -c
+  #       - |
+  #         sudo apt-get update \
+  #           && sudo apt-get install -y docker.io
+
 ## Enable an Specify container in extraContainers.
 ## This is meant to allow adding code-server dependencies, like docker-dind.
 extraContainers: |
 # If docker-dind is used, DOCKER_HOST env is mandatory to set in "extraVars"
-#- name: docker-dind
-#  image: docker:19.03-dind
-#  imagePullPolicy: IfNotPresent
-#  resources:
-#    requests:
-#      cpu: 250m
-#      memory: 256M
-#  securityContext:
-#    privileged: true
-#    procMount: Default
-#  env:
-#  - name: DOCKER_TLS_CERTDIR
-#    value: ""
-#  - name: DOCKER_DRIVER
-#    value: "overlay2"
+# - name: docker-dind
+#   image: docker:28.3.2-dind
+#   imagePullPolicy: IfNotPresent
+#   resources:
+#     requests:
+#       cpu: 1
+#       ephemeral-storage: "50Gi"
+#       memory: 10Gi
+#   securityContext:
+#     privileged: true
+#     procMount: Default
+#   env:
+#     - name: DOCKER_TLS_CERTDIR
+#       value: "" # disable TLS setup
+#   command:
+#     - dockerd
+#     - --host=unix:///var/run/docker.sock
+#     - --host=tcp://0.0.0.0:2376
+
 
 extraInitContainers: |
 # - name: customization

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -383,8 +383,8 @@ mount into `/home/coder/myproject` from inside the `code-server` container. You
 need to make sure the Docker daemon's `/home/coder/myproject` is the same as the
 one mounted inside the `code-server` container, and the mount will work.
 
-If you want docker enabled when deploying on kubernetes, look at the `values.yaml`
-file for the 3 fields: `extraVars`, `lifecycle.postStart`, and `extraContainers`. 
+If you want Docker enabled when deploying on Kubernetes, look at the `values.yaml`
+file for the 3 fields: `extraVars`, `lifecycle.postStart`, and `extraContainers`.
 
 ## How do I disable telemetry?
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -383,6 +383,9 @@ mount into `/home/coder/myproject` from inside the `code-server` container. You
 need to make sure the Docker daemon's `/home/coder/myproject` is the same as the
 one mounted inside the `code-server` container, and the mount will work.
 
+If you want docker enabled when deploying on kubernetes, look at the `values.yaml`
+file for the 3 fields: `extraVars`, `lifecycle.postStart`, and `extraContainers`. 
+
 ## How do I disable telemetry?
 
 Use the `--disable-telemetry` flag to disable telemetry.


### PR DESCRIPTION
See issue: https://github.com/coder/code-server/issues/7429

This PR updates the commented out defaults in the `values.yaml` to support docker-in-docker when deploying code-server on kubernetes. 

The existing values were too out of date and no longer worked. By using these values, in a vanilla cluster, one can run `docker ps` and `docker run hello-world` without any other additional setup. 
