### PR TITLE
chore: "ubuntu" tagged docker image should use "noble" (24.04) instead of 6 year old "focal" (20.04)

### DIFF
--- a/ci/release-image/docker-bake.hcl
+++ b/ci/release-image/docker-bake.hcl
@@ -73,7 +73,6 @@ target "code-server-debian-12" {
 target "code-server-ubuntu-focal" {
     dockerfile = "ci/release-image/Dockerfile"
     tags = concat(
-        gen_tags_for_docker_and_ghcr("ubuntu"),
         gen_tags_for_docker_and_ghcr("focal"),
     )
     args = {
@@ -86,6 +85,7 @@ target "code-server-ubuntu-noble" {
     dockerfile = "ci/release-image/Dockerfile"
     tags = concat(
         gen_tags_for_docker_and_ghcr("noble"),
+        gen_tags_for_docker_and_ghcr("ubuntu"),
     )
     args = {
         BASE = "ubuntu:noble"


### PR DESCRIPTION

Fixes #7762
