### PR TITLE
Update Code to 1.118.0

### DIFF
--- a/patches/clipboard.diff
+++ b/patches/clipboard.diff
@@ -78,7 +78,7 @@ Index: code-server/lib/vscode/src/vs/platform/environment/common/argv.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/platform/environment/common/argv.ts
 +++ code-server/lib/vscode/src/vs/platform/environment/common/argv.ts
-@@ -145,6 +145,7 @@ export interface NativeParsedArgs {
+@@ -149,6 +149,7 @@ export interface NativeParsedArgs {
  	'disable-chromium-sandbox'?: boolean;
  	sandbox?: boolean;
  	'enable-coi'?: boolean;

--- a/patches/copilot.diff
+++ b/patches/copilot.diff
@@ -2,7 +2,7 @@ Index: code-server/lib/vscode/build/gulpfile.extensions.ts
 ===================================================================
 --- code-server.orig/lib/vscode/build/gulpfile.extensions.ts
 +++ code-server/lib/vscode/build/gulpfile.extensions.ts
-@@ -287,6 +287,29 @@ export const compileCopilotExtensionBuil
+@@ -293,6 +293,29 @@ export const compileCopilotExtensionBuil
  gulp.task(compileCopilotExtensionBuildTask);
  
  /**

--- a/patches/copilot.diff
+++ b/patches/copilot.diff
@@ -40,7 +40,7 @@ Index: code-server/lib/vscode/build/lib/extensions.ts
  import { type IExtensionDefinition, getExtensionStream } from './builtInExtensions.ts';
  import { fetchUrls, fetchGithub } from './fetch.ts';
  import { createTsgoStream, spawnTsgo } from './tsgo.ts';
-+import { prepareBuiltInCopilotExtensionShims } from './copilot.ts';
++import { prepareBuiltInCopilotRipgrepShim } from './copilot.ts';
  import vzip from 'gulp-vinyl-zip';
  
  import { createRequire } from 'module';
@@ -148,7 +148,7 @@ Index: code-server/lib/vscode/build/lib/extensions.ts
 +	}
 +
 +	try {
-+		prepareBuiltInCopilotExtensionShims(platform, arch, outputDir, appNodeModulesDir);
++		prepareBuiltInCopilotRipgrepShim(platform, arch, outputDir, appNodeModulesDir);
 +		fancyLog(`[prepareCopilotExtensionNativeShims] Materialized native shims for ${platform}-${arch}`);
 +	} catch (err) {
 +		// Downgrade to a warning for local builds since the extension

--- a/patches/unique-db.diff
+++ b/patches/unique-db.diff
@@ -21,7 +21,7 @@ Index: code-server/lib/vscode/src/vs/workbench/services/storage/browser/storageS
  
  export class BrowserStorageService extends AbstractStorageService {
  
-@@ -300,7 +301,11 @@ export class IndexedDBStorageDatabase ex
+@@ -328,7 +329,11 @@ export class IndexedDBStorageDatabase ex
  	}
  
  	static async createWorkspaceStorage(workspaceId: string, logService: ILogService): Promise<IIndexedDBStorageDatabase> {

--- a/patches/update-check.diff
+++ b/patches/update-check.diff
@@ -101,7 +101,7 @@ Index: code-server/lib/vscode/src/vs/base/common/product.ts
  
  	readonly version: string;
  	readonly date?: string;
-@@ -118,6 +119,7 @@ export interface IProductConfiguration {
+@@ -119,6 +120,7 @@ export interface IProductConfiguration {
  		readonly resourceUrlTemplate: string;
  		readonly nlsBaseUrl: string;
  		readonly accessSKUs?: string[];

--- a/patches/webview.diff
+++ b/patches/webview.diff
@@ -70,21 +70,12 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/webview/browser/pre/index
  	<meta charset="UTF-8">
  
  	<meta http-equiv="Content-Security-Policy"
--		content="default-src 'none'; script-src 'sha256-TaWGDzV7c9rUH2q/5ygOyYUHSyHIqBMYfucPh3lnKvU=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+-		content="default-src 'none'; script-src 'sha256-q+WTr+fBXpLLE3++yWNaxT6BTWQtsKscoeIlynBRk4E=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 +		content="default-src 'none'; script-src 'sha256-nQZh+9dHKZP2cHbhYlCbWDtqxxJtGjRGBx57zNP2DZM=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
  
  	<!-- Disable pinch zooming -->
  	<meta name="viewport"
-@@ -256,7 +256,7 @@
- 			}
- 
- 			const swPath = encodeURI(`service-worker.js?v=${expectedWorkerVersion}&vscode-resource-base-authority=${searchParams.get('vscode-resource-base-authority')}&remoteAuthority=${searchParams.get('remoteAuthority') ?? ''}`);
--			navigator.serviceWorker.register(swPath, { type: 'module' })
-+			navigator.serviceWorker.register(swPath)
- 				.then(async registration => {
- 					/**
- 					 * @param {MessageEvent} event
-@@ -370,6 +370,12 @@
+@@ -332,6 +332,12 @@
  
  				const hostname = location.hostname;
  

--- a/patches/webview.diff
+++ b/patches/webview.diff
@@ -71,10 +71,19 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/webview/browser/pre/index
  
  	<meta http-equiv="Content-Security-Policy"
 -		content="default-src 'none'; script-src 'sha256-q+WTr+fBXpLLE3++yWNaxT6BTWQtsKscoeIlynBRk4E=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
-+		content="default-src 'none'; script-src 'sha256-TRhQKOVfHYg34NwPrDGzFSP3l32HL8sgSHYg4kYl0ho=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
++		content="default-src 'none'; script-src 'sha256-m1DlJtsIJd46QuWYNcsaYIG1xI+9FyjKQu+cfp+zq5Q=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
  
  	<!-- Disable pinch zooming -->
  	<meta name="viewport"
+@@ -253,7 +253,7 @@
+ 			}
+ 
+ 			const swPath = encodeURI(`service-worker.js?v=${expectedWorkerVersion}&vscode-resource-base-authority=${searchParams.get('vscode-resource-base-authority')}&remoteAuthority=${searchParams.get('remoteAuthority') ?? ''}`);
+-			navigator.serviceWorker.register(swPath, { type: 'module', updateViaCache: 'none' })
++			navigator.serviceWorker.register(swPath)
+ 				.then(async registration => {
+ 					if (navigator.serviceWorker.controller) {
+ 						// A previous SW is already controlling. Force an update
 @@ -332,6 +332,12 @@
  
  				const hostname = location.hostname;

--- a/patches/webview.diff
+++ b/patches/webview.diff
@@ -71,7 +71,7 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/webview/browser/pre/index
  
  	<meta http-equiv="Content-Security-Policy"
 -		content="default-src 'none'; script-src 'sha256-q+WTr+fBXpLLE3++yWNaxT6BTWQtsKscoeIlynBRk4E=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
-+		content="default-src 'none'; script-src 'sha256-nQZh+9dHKZP2cHbhYlCbWDtqxxJtGjRGBx57zNP2DZM=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
++		content="default-src 'none'; script-src 'sha256-TRhQKOVfHYg34NwPrDGzFSP3l32HL8sgSHYg4kYl0ho=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
  
  	<!-- Disable pinch zooming -->
  	<meta name="viewport"


### PR DESCRIPTION
`npm run build:vscode` will output

```
...
SyntaxError: The requested module './copilot.ts' does not provide an export named 'prepareBuiltInCopilotExtensionShims'
    at ModuleJobSync.runSync (node:internal/modules/esm/module_job:440:37)
    at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:435:47)
    at loadESMFromCJS (node:internal/modules/cjs/loader:1536:24)
    at Module._compile (node:internal/modules/cjs/loader:1687:5)
    at Object..js (node:internal/modules/cjs/loader:1838:10)
    at Module.load (node:internal/modules/cjs/loader:1441:32)
    at Function._load (node:internal/modules/cjs/loader:1263:12)
    at TracingChannel.traceSync (node:diagnostics_channel:328:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:237:24)
    at Module.require (node:internal/modules/cjs/loader:1463:12)
```