### PR TITLE
fix: apply --app-name to web page titles

### DIFF
--- a/patches/app-name.diff
+++ b/patches/app-name.diff
@@ -1,0 +1,26 @@
+Apply --app-name to VS Code web page titles
+
+VS Code's `${appName}` title variable comes from `productService.nameLong` in the
+web client. code-server already injects per-request product configuration into
+VS Code's web bootstrap, so set `nameShort`/`nameLong` from the existing
+`--app-name` CLI arg there.
+
+This keeps the patch minimal and makes browser tab titles honor `--app-name`
+without changing unrelated product metadata.
+
+Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/server/node/webClientServer.ts
++++ code-server/lib/vscode/src/vs/server/node/webClientServer.ts
+@@ -333,8 +333,11 @@ export class WebClientServer {
+ 			scopes: [['user:email'], ['repo']]
+ 		} : undefined;
+ 
++		const appName = this._environmentService.args['app-name'];
+ 		const productConfiguration = {
+ 			embedderIdentifier: 'server-distro',
++			nameShort: appName,
++			nameLong: appName,
+ 			extensionsGallery: this._webExtensionResourceUrlTemplate && this._productService.extensionsGallery ? {
+ 				...this._productService.extensionsGallery,
+ 				resourceUrlTemplate: this._webExtensionResourceUrlTemplate.with({

--- a/patches/app-name.diff
+++ b/patches/app-name.diff
@@ -12,15 +12,15 @@ Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/server/node/webClientServer.ts
 +++ code-server/lib/vscode/src/vs/server/node/webClientServer.ts
-@@ -333,8 +333,11 @@ export class WebClientServer {
- 			scopes: [['user:email'], ['repo']]
- 		} : undefined;
+@@ -366,8 +366,11 @@ export class WebClientServer {
+ 			linkProtectionTrustedDomains.push(...this._productService.linkProtectionTrustedDomains);
+ 		}
  
 +		const appName = this._environmentService.args['app-name'];
- 		const productConfiguration = {
- 			embedderIdentifier: 'server-distro',
+ 		const productConfiguration: Partial<Mutable<IProductConfiguration>> = {
+ 			codeServerVersion: this._productService.codeServerVersion,
 +			nameShort: appName,
 +			nameLong: appName,
- 			extensionsGallery: this._webExtensionResourceUrlTemplate && this._productService.extensionsGallery ? {
- 				...this._productService.extensionsGallery,
- 				resourceUrlTemplate: this._webExtensionResourceUrlTemplate.with({
+ 			rootEndpoint: rootBase,
+ 			updateEndpoint: !this._environmentService.args['disable-update-check'] ? rootBase + '/update/check' : undefined,
+ 			logoutEndpoint: this._environmentService.args['auth'] && this._environmentService.args['auth'] !== "none" ? rootBase + '/logout' : undefined,

--- a/patches/app-name.diff
+++ b/patches/app-name.diff
@@ -8,6 +8,26 @@ VS Code's web bootstrap, so set `nameShort`/`nameLong` from the existing
 This keeps the patch minimal and makes browser tab titles honor `--app-name`
 without changing unrelated product metadata.
 
+Index: code-server/lib/vscode/src/vs/server/node/serverEnvironmentService.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/server/node/serverEnvironmentService.ts
++++ code-server/lib/vscode/src/vs/server/node/serverEnvironmentService.ts
+@@ -24,6 +24,7 @@ export const serverOptions: OptionDescri
+ 	'disable-getting-started-override': { type: 'boolean' },
+ 	'locale': { type: 'string' },
+ 	'link-protection-trusted-domains': { type: 'string[]' },
++	'app-name': { type: 'string' },
+ 
+ 	/* ----- server setup ----- */
+ 
+@@ -120,6 +121,7 @@ export interface ServerParsedArgs {
+ 	'disable-getting-started-override'?: boolean,
+ 	'locale'?: string
+ 	'link-protection-trusted-domains'?: string[],
++	'app-name'?: string,
+ 
+ 	/* ----- server setup ----- */
+ 
 Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/server/node/webClientServer.ts

--- a/patches/series
+++ b/patches/series
@@ -23,3 +23,4 @@ display-language.diff
 trusted-domains.diff
 signature-verification.diff
 copilot.diff
+app-name.diff

--- a/test/e2e/appName.test.ts
+++ b/test/e2e/appName.test.ts
@@ -1,0 +1,9 @@
+import { version } from "../../src/node/constants"
+import { describe, test, expect } from "./baseFixture"
+
+const appName = "testnäme"
+describe("--app-name", [`--app-name=${appName}`], {}, () => {
+  test("should use app-name for the title", async ({ codeServerPage }) => {
+    expect(await codeServerPage.page.title()).toContain(appName)
+  })
+})

--- a/test/unit/node/routes/vscode.test.ts
+++ b/test/unit/node/routes/vscode.test.ts
@@ -27,4 +27,16 @@ describe("vscode", () => {
       })
     }).rejects.toThrow()
   })
+
+  it("should apply app-name to the VS Code product configuration", async () => {
+    const appName = "testnäme"
+    codeServer = await integration.setup(["--auth=none", `--app-name=${appName}`], "")
+
+    const resp = await codeServer.fetch("/vscode")
+    const htmlContent = await resp.text()
+
+    expect(resp.status).toBe(200)
+    expect(htmlContent).toContain(`\"nameShort\":\"${appName}\"`)
+    expect(htmlContent).toContain(`\"nameLong\":\"${appName}\"`)
+  })
 })

--- a/test/unit/node/routes/vscode.test.ts
+++ b/test/unit/node/routes/vscode.test.ts
@@ -36,7 +36,7 @@ describe("vscode", () => {
     const htmlContent = await resp.text()
 
     expect(resp.status).toBe(200)
-    expect(htmlContent).toContain(`\"nameShort\":\"${appName}\"`)
-    expect(htmlContent).toContain(`\"nameLong\":\"${appName}\"`)
+    expect(htmlContent).toContain(`"nameShort":"${appName}"`)
+    expect(htmlContent).toContain(`"nameLong":"${appName}"`)
   })
 })

--- a/test/unit/node/routes/vscode.test.ts
+++ b/test/unit/node/routes/vscode.test.ts
@@ -27,16 +27,4 @@ describe("vscode", () => {
       })
     }).rejects.toThrow()
   })
-
-  it("should apply app-name to the VS Code product configuration", async () => {
-    const appName = "testnäme"
-    codeServer = await integration.setup(["--auth=none", `--app-name=${appName}`], "")
-
-    const resp = await codeServer.fetch("/vscode")
-    const htmlContent = await resp.text()
-
-    expect(resp.status).toBe(200)
-    expect(htmlContent).toContain(`"nameShort":"${appName}"`)
-    expect(htmlContent).toContain(`"nameLong":"${appName}"`)
-  })
 })


### PR DESCRIPTION
An exact copy of the PR in #7725 by @jonathandunne, but rebased against latest.  Fixes #7688  Original PR description below:
## Summary
- apply `--app-name` to VS Code web bootstrap product configuration
- set `nameShort`/`nameLong` so `${appName}` in tab titles uses the configured app name
- add a focused route test covering the injected configuration

## Testing
- attempted `npm install` (partially completed but failed in `lib/vscode` on missing `gssapi/gssapi.h` for `kerberos` under Node 24)
- attempted `npm run test:unit -- --runInBand --runTestsByPath test/unit/node/routes/vscode.test.ts test/unit/node/routes/login.test.ts`
- test run was blocked by a pre-existing TypeScript error in `src/node/http.ts` (`auth.cookie-max-age` missing on `DefaultedArgs`) before these route tests executed