### PR TITLE
Make app-name configurable via environment variable.

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -677,9 +677,7 @@ export async function setDefaults(cliArgs: UserProvidedArgs, configArgs?: Config
   }
   args["proxy-domain"] = finalProxies
 
-  if (!args["app-name"]) {
-    args["app-name"] = "code-server"
-  }
+  args["app-name"] ??= process.env.CODE_SERVER_APP_NAME || "code-server"
 
   args._ = getResolvedPathsFromArgs(args)
 


### PR DESCRIPTION
Related to #7794 and continues fix to #7688.

I realized that CLI option is really inconvenient for my current setup, which is a general purpose code-server docker container that I can launch from any source code folder on my computer such that it is fully isolated via docker, but also retains my configuration settings.  It has an entrypoint that sets the workspace, but the CLI doesn't let you pass additional arguments after the workspace so I can't just add `--app-name $APP_NAME`.

By making it an environment variable, I can simply provide the environment variable to docker run, and it will use that if `--app-name` isn't provided.