### PR TITLE
Fix false positive CVE alerts from bundled VS Code package.json

### DIFF
--- a/ci/build/build-release.sh
+++ b/ci/build/build-release.sh
@@ -128,7 +128,9 @@ bundle_vscode() {
 
   # Merge the package.json for the web/remote server so we can include
   # dependencies, since we want to ship this via NPM.
-  jq --slurp '.[0] * .[1]' \
+  # Also override the name to prevent vulnerability scanners from
+  # misidentifying this package as VS Code (see #7071).
+  jq --slurp '.[0] * .[1] | .name = "code-oss-dev"' \
     "$VSCODE_SRC_PATH/remote/package.json" \
     "$VSCODE_OUT_PATH/package.json" > "$VSCODE_OUT_PATH/package.json.merged"
   mv "$VSCODE_OUT_PATH/package.json.merged" "$VSCODE_OUT_PATH/package.json"


### PR DESCRIPTION
Fixes #7071                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                        
The VS Code build process (`gulpfile.reh.ts`) writes `product.json`'s                                                                                                                                                                                                                                                                                 
`nameShort` ("code-server") into the bundled `lib/vscode/package.json`                                                                                                                                                                                                                                                                                
`name` field. Vulnerability scanners (e.g. Anchore Grype) then match                                                                                                                                                                                                                                                                                  
this against CVE databases using the combination of `name: "code-server"`                                                                                                                                                                                                                                                                             
and `version: "1.x.x"` (the VS Code version), producing false positives                                                                                                                                                                                                                                                                               
like GHSA-frjg-g767-7363.                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                      
This overrides the `name` to `"code-oss-dev"` in `build-release.sh`                                                                                                                                                                                                                                                                                   
after merging the package.json, so scanners can no longer match it                                                                                                                                                                                                                                                                                    
against known CVE entries for code-server.