### PR TITLE
Support stylus/pen text selection on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Code v99.99.999
 
 ## Unreleased
 
+### Added
+
+- Selecting editor text with a stylus or pen now works on Android, like it
+  already did on iOS. A finger still scrolls.
+
 ## [4.123.0](https://github.com/coder/code-server/releases/tag/v4.123.0) - 2026-06-03
 
 Code v1.123.0

--- a/patches/pen-support.diff
+++ b/patches/pen-support.diff
@@ -1,0 +1,36 @@
+Support stylus/pen text selection on Android
+
+The editor only uses the pen-aware PointerEventHandler on iOS, or on Android
+when platform.isMobile is true. That flag comes from a "Mobi" token in the user
+agent string, which Android tablets usually leave out, so on a tablet the editor
+fell back to TouchHandler. A stylus could then scroll but never select text.
+
+This widens the check so any Android device gets PointerEventHandler when
+Pointer Events are available, the same as iOS already does. The iOS branch is
+left alone. Once PointerEventHandler is active, a pen drag selects text, a
+finger drag still scrolls, the pen's barrel button opens the context menu, and
+the mouse keeps working as before.
+
+To test:
+
+1. Open code-server in Chrome on an Android tablet. (In desktop Chrome you can
+   also use DevTools device mode with an Android tablet user agent that has no
+   "Mobi" token.)
+2. Open a file.
+3. Drag across text with a stylus or pen. The text should select.
+4. Drag with a finger. The editor should scroll.
+5. With a mouse, selection and right-click should behave as before.
+
+Index: code-server/lib/vscode/src/vs/editor/browser/controller/pointerHandler.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/editor/browser/controller/pointerHandler.ts
++++ code-server/lib/vscode/src/vs/editor/browser/controller/pointerHandler.ts
+@@ -141,7 +141,7 @@ export class PointerHandler extends Disp
+ 
+ 	constructor(context: ViewContext, viewController: ViewController, viewHelper: IPointerHandlerHelper) {
+ 		super();
+-		const isPhone = platform.isIOS || (platform.isAndroid && platform.isMobile);
++		const isPhone = platform.isIOS || platform.isAndroid;
+ 		if (isPhone && BrowserFeatures.pointerEvents) {
+ 			this.handler = this._register(new PointerEventHandler(context, viewController, viewHelper));
+ 		} else if (mainWindow.TouchEvent) {

--- a/patches/series
+++ b/patches/series
@@ -24,3 +24,4 @@ trusted-domains.diff
 signature-verification.diff
 copilot.diff
 app-name.diff
+pen-support.diff


### PR DESCRIPTION
## What this does

  A stylus or pen drag now selects text in the editor on Android, the same as it
  already does on iOS. A finger drag still scrolls, and the mouse is unchanged.

  ## Why

  The editor only sends pointer input through PointerEventHandler, the handler
  that lets a pen select while touch scrolls, on iOS or on Android when
  platform.isMobile is true. platform.isMobile looks for a "Mobi" token in the
  user agent, and Android tablets usually leave that token out. So on a tablet the
  editor fell back to TouchHandler, and a stylus could only scroll, never select.
  Android phones were unaffected because their user agent carries "Mobi".

  Background: microsoft/vscode#198578 added the pen/stylus selection path for
  mobile; this extends it to Android tablets.

  ## The change

  One line, in a new patch (patches/pen-support.diff):

  ```diff
  -             const isPhone = platform.isIOS || (platform.isAndroid && platform.isMobile);
  +             const isPhone = platform.isIOS || platform.isAndroid;
  ```

  The iOS branch is left as is. The only difference is that Android no longer
  requires the isMobile flag to reach PointerEventHandler.

  ## Testing

  Built and run on a Samsung tablet with an S Pen, in Chrome:

  - Pen drag across text selects it.
  - Finger drag scrolls.
  - Pen barrel button plus a tap opens the context menu.
  - Mouse selection and right-click are unchanged.

  Also reproducible in desktop Chrome with DevTools device mode set to an Android
  tablet user agent that has no "Mobi" token.

  ## Notes

  iPad and iPhone are unaffected; the iOS branch is untouched. Android phones are
  unaffected too, since they already satisfied isMobile.