### PR TITLE
fix: preserve path and query in openExternal URL rewrite

### DIFF
--- a/patches/proxy-uri.diff
+++ b/patches/proxy-uri.diff
@@ -27,7 +27,7 @@ http.server` and it should show a notification and show up in the ports panel
 using the /proxy/port.
 
 Index: code-server/lib/vscode/src/vs/base/common/product.ts
-===================================================================
+====================================================================
 --- code-server.orig/lib/vscode/src/vs/base/common/product.ts
 +++ code-server/lib/vscode/src/vs/base/common/product.ts
 @@ -69,6 +69,7 @@ export interface IProductConfiguration {
@@ -54,7 +54,7 @@ Index: code-server/lib/vscode/src/vs/platform/remote/browser/remoteAuthorityReso
 @@ -86,9 +86,14 @@ export class RemoteAuthorityResolverServ
  		const connectionToken = await Promise.resolve(this._connectionTokens.get(authority) || this._connectionToken);
  		performance.mark(`code/didResolveConnectionToken/${authorityPrefix}`);
- 		this._logService.info(`Resolved connection token (${authorityPrefix}) after ${sw.elapsed()} ms`);
+ 		this._blogService.info(`Resolved connection token (${authorityPrefix}) after ${sw.elapsed()} ms`);
 +		let options: ResolvedOptions | undefined;
 +		if (this.productService.proxyEndpointTemplate) {
 +			const proxyUrl = new URL(this.productService.proxyEndpointTemplate, mainWindow.location.href);
@@ -68,13 +68,13 @@ Index: code-server/lib/vscode/src/vs/platform/remote/browser/remoteAuthorityReso
  		this._cache.set(authority, result);
  		this._onDidChangeConnectionData.fire();
 Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
-===================================================================
+=====================================================================
 --- code-server.orig/lib/vscode/src/vs/server/node/webClientServer.ts
 +++ code-server/lib/vscode/src/vs/server/node/webClientServer.ts
 @@ -362,6 +362,7 @@ export class WebClientServer {
  			rootEndpoint: rootBase,
- 			updateEndpoint: !this._environmentService.args['disable-update-check'] ? rootBase + '/update/check' : undefined,
- 			logoutEndpoint: this._environmentService.args['auth'] && this._environmentService.args['auth'] !== "none" ? rootBase + '/logout' : undefined,
+ 		updateEndpoint: !this._environmentService.args['disable-update-check'] ? rootBase + '/update/check' : undefined,
+ 		logoutEndpoint: this._environmentService.args['auth'] && this._environmentService.args['auth'] !== "none" ? rootBase + '/logout' : undefined,
 +			proxyEndpointTemplate: process.env.VSCODE_PROXY_URI ?? rootBase + '/proxy/{{port}}/',
  			embedderIdentifier: 'server-distro',
  			extensionsGallery: this._productService.extensionsGallery,
@@ -126,7 +126,7 @@ Index: code-server/lib/vscode/src/vs/code/browser/workbench/workbench.ts
 +					}
 +					resolvedUri = URI.parse(proxyUrl.toString())
 +				} else {
-+					throw new Error(Failed to resolve external URI: ${uri.toString()}. Could not determine base url because productConfiguration missing.)
++					throw new Error(`Failed to resolve external URI: ${uri.toString()}. Could not determine base url because productConfiguration missing.`)
 +				}
 +			}
 +			// If not localhost, return unmodified.
@@ -153,7 +153,7 @@ Index: code-server/lib/vscode/src/vs/code/browser/workbench/workbench.ts
  			? undefined /* with a remote without embedder-preferred storage, store on the remote */
  			: new LocalStorageSecretStorageProvider(secretStorageCrypto),
 Index: code-server/lib/vscode/src/vs/workbench/contrib/remote/browser/remoteExplorer.ts
-===================================================================
+==================================================================9
 --- code-server.orig/lib/vscode/src/vs/workbench/contrib/remote/browser/remoteExplorer.ts
 +++ code-server/lib/vscode/src/vs/workbench/contrib/remote/browser/remoteExplorer.ts
 @@ -83,8 +83,8 @@ export class ForwardedPortsView extends
@@ -167,3 +167,4 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/remote/browser/remoteExpl
  
  		if (featuresEnabled || viewEnabled) {
  			// Also enable the view if it isn't already.
+

--- a/patches/proxy-uri.diff
+++ b/patches/proxy-uri.diff
@@ -104,7 +104,7 @@ Index: code-server/lib/vscode/src/vs/code/browser/workbench/workbench.ts
  import type { IURLCallbackProvider } from '../../../workbench/services/url/browser/urlService.js';
  import { create } from '../../../workbench/workbench.web.main.internal.js';
  
-@@ -612,6 +613,39 @@ class WorkspaceProvider implements IWork
+@@ -612,6 +613,44 @@ class WorkspaceProvider implements IWork
  		settingsSyncOptions: config.settingsSyncOptions ? { enabled: config.settingsSyncOptions.enabled, } : undefined,
  		workspaceProvider: WorkspaceProvider.create(config),
  		urlCallbackProvider: new LocalStorageURLCallbackProvider(config.callbackRoute),
@@ -116,9 +116,17 @@ Index: code-server/lib/vscode/src/vs/code/browser/workbench/workbench.ts
 +					const renderedTemplate = config.productConfiguration.proxyEndpointTemplate
 +						.replace('{{port}}', localhostMatch.port.toString())
 +						.replace('{{host}}', window.location.host)
-+					resolvedUri = URI.parse(new URL(renderedTemplate, window.location.href).toString())
++					const proxyUrl = new URL(renderedTemplate, window.location.href)
++					// Preserve the original path and query string
++					if (resolvedUri.path && resolvedUri.path !== '/') {
++						proxyUrl.pathname += resolvedUri.path.substring(1)
++					}
++					if (resolvedUri.query) {
++						proxyUrl.search = resolvedUri.query
++					}
++					resolvedUri = URI.parse(proxyUrl.toString())
 +				} else {
-+					throw new Error(`Failed to resolve external URI: ${uri.toString()}. Could not determine base url because productConfiguration missing.`)
++					throw new Error(Failed to resolve external URI: ${uri.toString()}. Could not determine base url because productConfiguration missing.)
 +				}
 +			}
 +			// If not localhost, return unmodified.


### PR DESCRIPTION
## Description

Fixes #7668: The esolveExternalUri function in the proxy-uri patch was discarding the original URI path and query parameters when rewriting localhost URLs to go through the code-server proxy.

### Before
`http://127.0.0.1:1234/my/path?q=1` → `/proxy/1234/`

### After  
`http://127.0.0.1:1234/my/path?q=1` → `/proxy/1234/my/path?q=1`

## Changes
- Store the constructed proxy URL in a variable first
- Append the original URI path (with leading `/` stripped) to the proxy URL pathname
- Preserve the original URI query string by assigning it to the proxy URL search property

## Testing
The fix preserves the path and query parameters from localhost URLs when they are rewritten through the code-server proxy endpoint template.