### PR TITLE
Backport installer workflow permissions hardening to v4.1.0

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   ubuntu:
     name: Test installer on Ubuntu


### PR DESCRIPTION
Backports the minimal GitHub Actions hardening from `main` to `v4.1.0` for `.github/workflows/installer.yml` only.

Related issue: https://github.com/coder/code-server/issues/7865
Reference workflow: https://github.com/coder/code-server/blob/v4.1.0/.github/workflows/installer.yml

Validation:
- `git diff --check`
- `actionlint` on `.github/workflows/installer.yml`
- `zizmor` on `.github/workflows/installer.yml`

Notes:
- The change is limited to `permissions: contents: read` at workflow level.
- The commit is signed.