### PR TITLE
docs: document opening a file at a line via the payload query parameter

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -17,6 +17,7 @@
 - [Where is VS Code configuration stored?](#where-is-vs-code-configuration-stored)
 - [How can I reuse my VS Code configuration?](#how-can-i-reuse-my-vs-code-configuration)
 - [How does code-server decide what workspace or folder to open?](#how-does-code-server-decide-what-workspace-or-folder-to-open)
+- [Can I open a file at a specific line from a URL?](#can-i-open-a-file-at-a-specific-line-from-a-url)
 - [How do I access my Documents/Downloads/Desktop folders in code-server on macOS?](#how-do-i-access-my-documentsdownloadsdesktop-folders-in-code-server-on-macos)
 - [How do I direct server-side requests through a proxy?](#how-do-i-direct-server-side-requests-through-a-proxy)
 - [How do I debug issues with code-server?](#how-do-i-debug-issues-with-code-server)
@@ -229,6 +230,39 @@ code-server tries the following in this order:
 2. The `folder` query parameter
 3. The workspace or directory passed via the command line
 4. The last opened workspace or directory
+
+## Can I open a file at a specific line from a URL?
+
+Yes. In addition to `workspace` and `folder`, code-server supports VS Code's
+`payload` query parameter, which can open a specific file — optionally at a
+line and column — once the workbench loads.
+
+`payload` is a URL-encoded JSON array of `[key, value]` string pairs. The
+`openFile` key takes a `vscode-remote://<host>/<absolute path>` URI, where
+`<host>` is the host you use to reach code-server. Add
+`["gotoLineMode","true"]` to have a trailing `:line[:column]` suffix on the
+path interpreted as a cursor position:
+
+```text
+https://code.example.com/?folder=/home/coder/project&payload=[["gotoLineMode","true"],["openFile","vscode-remote://code.example.com/home/coder/project/src/app.py:10:5"]]
+```
+
+(with the `payload` value URL-encoded). Notes:
+
+- Paths must be absolute; there is no form relative to `folder`.
+- This is upstream VS Code web behavior (the same mechanism vscode.dev uses),
+  so it works without any code-server-specific configuration.
+
+For example, to generate links from a shell:
+
+```sh
+#!/bin/sh
+# usage: code-link <absolute-file> [line[:column]]
+HOST=code.example.com
+payload="[[\"gotoLineMode\",\"true\"],[\"openFile\",\"vscode-remote://$HOST$1${2:+:$2}\"]]"
+printf 'https://%s/?folder=%s&payload=%s\n' "$HOST" "$(dirname "$1")" \
+  "$(printf '%s' "$payload" | jq -sRr @uri)"
+```
 
 ## How do I access my Documents/Downloads/Desktop folders in code-server on macOS?
 


### PR DESCRIPTION
Relates to #1964.

## What

Adds an FAQ entry documenting how to open a specific file — optionally at a line and column — directly from a URL, using the `payload` query parameter (`openFile` + `gotoLineMode`) alongside the existing `folder` parameter.

## Why

#1964 ("Ability to open a file directly using a URL") has been open since 2020 and is in the backlog, but the capability already exists: code-server inherits upstream VS Code web's `payload` query parameter, so no new patch is needed — it just isn't documented anywhere. The FAQ currently only mentions `workspace` and `folder`.

Verified working on code-server 4.122.1 behind a reverse proxy:

```
https://<host>/?folder=/tmp&payload=%5B%5B%22gotoLineMode%22%2C%22true%22%5D%2C%5B%22openFile%22%2C%22vscode-remote%3A%2F%2F%3Chost%3E%2Ftmp%2Ftest.txt%3A6%3A3%22%5D%5D
```

opens `/tmp/test.txt` with the cursor at line 6, column 3.

The new entry includes a small shell snippet for generating such links from a CLI (e.g. an `code <file> --line N` style wrapper that emits a browser link), which is the use case that keeps coming up in #1964.

