### PR TITLE
Update files to reflect the new node.js version

### DIFF
--- a/ci/build/npm-postinstall.sh
+++ b/ci/build/npm-postinstall.sh
@@ -65,8 +65,8 @@ main() {
     echo "USE AT YOUR OWN RISK!"
   fi
 
-  if [ "$major_node_version" -ne "${FORCE_NODE_VERSION:-22}" ]; then
-    echo "ERROR: code-server currently requires node v22."
+  if [ "$major_node_version" -ne "${FORCE_NODE_VERSION:-24}" ]; then
+    echo "ERROR: code-server currently requires node v24."
     if [ -n "$FORCE_NODE_VERSION" ]; then
       echo "However, you have overrided the version check to use v$FORCE_NODE_VERSION."
     fi

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -31,7 +31,7 @@ The prerequisites for contributing to code-server are almost the same as those
 for [VS Code](https://github.com/Microsoft/vscode/wiki/How-to-Contribute#prerequisites).
 Here is what is needed:
 
-- `node` v22.x
+- `node` v24.x
 - `git` v2.x or greater
 - [`git-lfs`](https://git-lfs.github.com)
 - [`npm`](https://www.npmjs.com/)

--- a/docs/android.md
+++ b/docs/android.md
@@ -11,11 +11,11 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ```
 
 6. Exit the terminal using `exit` and then reopen the terminal
-7. Install and use Node.js 22:
+7. Install and use Node.js 24:
 
 ```shell
-nvm install 22
-nvm use 22
+nvm install 24
+nvm use 24
 ```
 
 8. Install code-server globally on device with: `npm install --global code-server`

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -29,8 +29,7 @@ includes installing instructions based on your operating system.
 
 ## Node.js version
 
-We use the same major version of Node.js shipped with Code's remote, which is
-currently `22.x`. VS Code also [lists Node.js
+We use Node.js `24.x`. VS Code also [lists Node.js
 requirements](https://github.com/microsoft/vscode/wiki/How-to-Contribute#prerequisites).
 
 Using other versions of Node.js [may lead to unexpected
@@ -78,7 +77,7 @@ Proceed to [installing](#installing)
 ## FreeBSD
 
 ```sh
-pkg install -y git python npm-node22 pkgconf
+pkg install -y git python npm-node24 pkgconf
 pkg install -y libinotify
 ```
 

--- a/docs/termux.md
+++ b/docs/termux.md
@@ -57,7 +57,7 @@ npm config set python python3
 node -v
 ```
 
-you will get Node version `v22`
+you will get Node version `v24`
 
 5. Now install code-server following our guide on [installing with npm](./npm.md)
 


### PR DESCRIPTION
With the update to node.js v24 in vscode and package.json some files have not been updated and still referenced version 22.x.

I could not find an open issue for this, but I would argue the fix is minor enough. If you would like me to open an issue for this, let me know.