### PR TITLE
fix(npm): remove --unsafe-perm flag from install scripts

### DIFF
--- a/ci/build/npm-postinstall.sh
+++ b/ci/build/npm-postinstall.sh
@@ -76,20 +76,6 @@ main() {
     exit 1
   fi
 
-  # Under npm, if we are running as root, we need --unsafe-perm otherwise
-  # post-install scripts will not have sufficient permissions to do their thing.
-  if is_root; then
-    case "${npm_config_user_agent-}" in npm*)
-      if [ "${npm_config_unsafe_perm-}" != "true" ]; then
-        echo "Please pass --unsafe-perm to npm to install code-server"
-        echo "Otherwise post-install scripts will not have permissions to run"
-        echo "See https://docs.npmjs.com/misc/config#unsafe-perm"
-        echo "See https://stackoverflow.com/questions/49084929/npm-sudo-global-installation-unsafe-perm"
-        exit 1
-      fi
-      ;;
-    esac
-  fi
 
   if ! vscode_install; then
     echo "You may not have the required dependencies to build the native modules."
@@ -110,7 +96,7 @@ install_with_yarn_or_npm() {
   # end-user we want to keep using whatever package manager is in use.
   case "${npm_config_user_agent-}" in
     npm*)
-      if ! npm install --unsafe-perm --omit=dev; then
+      if ! npm install --omit=dev; then
         return 1
       fi
       ;;

--- a/install.sh
+++ b/install.sh
@@ -436,7 +436,7 @@ install_npm() {
     fi
     echoh "Installing with npm."
     echoh
-    "$sh_c" "$NPM_PATH" install -g "code-server@$VERSION" --unsafe-perm
+    "$sh_c" "$NPM_PATH" install -g "code-server@$VERSION"
     NPM_BIN_DIR="\$($NPM_PATH bin -g)" echo_npm_postinstall
     return
   fi


### PR DESCRIPTION
## Summary
Fixes #7950. Removes the --unsafe-perm flag from the three sites that pass or require it: npm 12 rejects unknown CLI flags (EUNKNOWNCONFIG) so the install dies before starting. The flag has been behaviorally irrelevant since npm v7.0.0 (2020): the changelog says the user/group/uid/gid/unsafe-perms configs are 'no longer relevant.' Scripts run as the working-dir owner regardless. 

## Changes
2 files: install.sh (drop flag from global install) + ci/build/npm-postinstall.sh (remove root guard that errors unless unsafe_perm=true, drop flag from dev-install). Validation: grep zero unsafe-perm refs, bash -n syntax OK, npm run test:scripts 34/34 pass. 

## Repro
 before: npm 12 + install -g code-server --unsafe-perm -> EUNKNOWNCONFIG. Follow-up tracked separately: npm 12 blocks postinstall scripts unless --allow-scripts is configured.