### PR TITLE
fix: run mklink through cmd so Windows npm install works

### DIFF
--- a/ci/build/npm-postinstall.sh
+++ b/ci/build/npm-postinstall.sh
@@ -18,7 +18,7 @@ symlink() {
   dest="$2"
   rm -rf "$dest"
   case $OS in
-    windows) mklink /J "$dest" "$source" ;;
+    windows) cmd //c mklink //J "$dest" "$source" ;;
     *) ln -s "$source" "$dest" ;;
   esac
 }


### PR DESCRIPTION
`npm install` on Windows (git-bash/MSYS) fails in postinstall with `mklink: command not found`. mklink is a cmd.exe builtin rather than an executable, so the sh running npm-postinstall.sh cannot exec it, and every symlink the install needs goes through this line.

Routing it through `cmd //c` fixes it. Verified on Windows 11: `mklink /J link src` from sh reports command not found, `cmd //c mklink //J link src` reports "Junction created" and a file reads correctly through the junction, using the same relative paths the symlink() call passes. The doubled slashes are MSYS argument escaping, safe here because this case only runs when the OS was detected as cygwin/mingw.

One of the failures behind the recipes in #1397.
