### PR TITLE
fix: guard FORCE_NODE_VERSION in the version error path

### DIFF
--- a/ci/build/npm-postinstall.sh
+++ b/ci/build/npm-postinstall.sh
@@ -67,7 +67,7 @@ main() {
 
   if [ "$major_node_version" -ne "${FORCE_NODE_VERSION:-24}" ]; then
     echo "ERROR: code-server currently requires node v24."
-    if [ -n "$FORCE_NODE_VERSION" ]; then
+    if [ -n "${FORCE_NODE_VERSION:-}" ]; then
       echo "However, you have overrided the version check to use v$FORCE_NODE_VERSION."
     fi
     echo "We have detected that you are on node v$major_node_version"


### PR DESCRIPTION
Installing on an unsupported node version dies with `FORCE_NODE_VERSION: unbound variable` instead of the intended error message. npm-postinstall.sh runs under `set -u`, and this is the one place the variable is read bare; the other reads all default it with `${FORCE_NODE_VERSION:-}`.

The lines the script never reaches are exactly the ones that tell the user the override exists and how to set it, so the people who need the message are the only ones who cannot see it.

Verified on Windows 11 with node 22 against 4.135.0: before, the install ends at the unbound variable; after, it prints the version error plus the override instructions and exits 1 as intended. Related to the install paths discussed in #1397.
