### PR TITLE
Add a windows launcher to the standalone release

### DIFF
--- a/ci/build/build-release.sh
+++ b/ci/build/build-release.sh
@@ -41,6 +41,11 @@ main() {
     rsync ./ci/build/code-server.sh "$RELEASE_PATH/bin/code-server"
     chmod 755 "$RELEASE_PATH/bin/code-server"
 
+    # Windows cannot run the shell launcher, so it gets one of its own.
+    if [ "$OS" = windows ]; then
+      rsync ./ci/build/code-server.cmd "$RELEASE_PATH/bin/code-server.cmd"
+    fi
+
     # Delete the extra bin scripts.
     rm "$RELEASE_PATH/lib/vscode/bin/remote-cli/code-darwin.sh"
     rm "$RELEASE_PATH/lib/vscode/bin/remote-cli/code-linux.sh"

--- a/ci/build/code-server.cmd
+++ b/ci/build/code-server.cmd
@@ -1,0 +1,8 @@
+@echo off
+
+rem This script is intended to be bundled into the standalone releases.
+rem Runs code-server with the bundled node binary.
+
+setlocal
+set "ROOT=%~dp0.."
+"%ROOT%\lib\node.exe" "%ROOT%" %*


### PR DESCRIPTION
The standalone release ships `bin/code-server`, a shell script that resolves its own location and execs the bundled node against the release root. Windows cannot run it, so a windows release arrives with no way to start it short of knowing where node ended up and typing both paths.

This adds the same launcher as a `.cmd`, copied into `bin/` only when `OS` is windows, so no other release changes at all. It is deliberately the shortest thing that works: `%~dp0` gives the bin directory, the root is one above it, and the bundled node is handed the root and every argument.

Verified against a real windows release tree: `--version` answers, it works from any working directory, and a bad flag comes back as exit code 1.

Two things a reviewer should know. The shell launcher resolves symlinks before computing the root, because of #1537. The `.cmd` does not, since `%~dp0` reports the directory of the link rather than of the target and batch has no readlink. A copy of the file works anywhere; a symlink to it does not.

The file is checked in with CRLF, which is what a `.cmd` needs on the platform it runs on and what a windows checkout would produce for it anyway.
