### PR TITLE
Detect the system on windows instead of reading Windows_NT

### DIFF
--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -49,7 +49,10 @@ if [[ ! ${ARCH-} ]]; then
   export ARCH
 fi
 
-if [[ ! ${OS-} ]]; then
+# Windows predefines OS as Windows_NT for every process, so on a windows shell
+# the check below would always find a value and never call os(). That is not a
+# name this build knows, so it does not count as one the caller chose.
+if [[ ! ${OS-} || ${OS-} == "Windows_NT" ]]; then
   OS=$(os)
   export OS
 fi


### PR DESCRIPTION
`ci/lib.sh` works out `OS` only when the caller has not set one:

```sh
if [[ ! ${OS-} ]]; then OS=$(os); fi
```

Windows predefines `OS` as `Windows_NT` in every process environment, so on a windows shell that test always finds a value, `os()` is never called, and `OS` stays `Windows_NT` for the whole build. Every question the build then asks about the system gets an answer it does not understand: which bin scripts to fix up, whether to build packages, what the release archive is called.

`os()` already handles this platform (`cygwin* | mingw*` answers windows), it just never gets the chance. `Windows_NT` is not a name this build knows, so it is not treated as one a caller chose.

Measured on a windows shell, sourcing the file three ways:

```
OS unset        -> windows   (was Windows_NT)
OS=Windows_NT   -> windows   (was Windows_NT)
OS=linux        -> linux     (unchanged)
```

so an explicit choice still wins, which is the point of the check. Nothing changes anywhere else: no other platform sets `OS`, so the added test is never reached off windows.

This is the "belongs in its own change" fix named in #7987; with it, that job's `OS: windows` env line becomes redundant rather than necessary.
